### PR TITLE
Add macOS support

### DIFF
--- a/openvaf/linker/src/lib.rs
+++ b/openvaf/linker/src/lib.rs
@@ -145,6 +145,8 @@ fn get_linker<'a>(
             let path = path.unwrap_or_else(|| {
                 if is_msys2_environment() {
                     "gcc".into()
+                } else if cfg!(target_os = "macos") {
+                    "clang".into()
                 } else {
                     "ld".into()
                 }
@@ -251,7 +253,8 @@ impl<'a> LdLinker<'a> {
     fn build_dylib(&mut self) {
         // On mac we need to tell the linker to let this library be rpathed
         if self.target.options.is_like_osx {
-            self.linker_arg("-dylib");
+            self.linker_arg("-dynamiclib");
+            // clang automatically handles -lSystem
         } else {
             self.linker_arg("-shared");
         }

--- a/openvaf/openvaf-driver/build.rs
+++ b/openvaf/openvaf-driver/build.rs
@@ -1,0 +1,17 @@
+// build.rs for openvaf-driver
+
+fn main() {
+    // Add rpath for LLVM on macOS
+    #[cfg(target_os = "macos")]
+    {
+        if let Ok(output) = std::process::Command::new("llvm-config")
+            .arg("--libdir")
+            .output()
+        {
+            if output.status.success() {
+                let libdir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                println!("cargo:rustc-link-arg=-Wl,-rpath,{}", libdir);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This allows OpenVAF to compile and run on macOS. The following changes were made:
- Use clang as linker on macOS instead of ld
- Change -dylib to -dynamiclib for clang compatibility
- Add build.rs to dynamically detect LLVM library path via llvm-config
- Add rpath to find libLLVM.dylib at runtime

Tested on macOS with MacPorts LLVM 18 on Apple Silicon.