### PR TITLE
Link libc++/libc++abi on macOS for static LLVM builds

### DIFF
--- a/openvaf/openvaf-driver/build.rs
+++ b/openvaf/openvaf-driver/build.rs
@@ -22,6 +22,14 @@ fn main() {
     // Add rpath for LLVM on macOS
     #[cfg(target_os = "macos")]
     {
+        // Official LLVM release tarballs ship only static component libs (no
+        // libLLVM.dylib), so llvm-sys's `prefer-dynamic` falls back to static
+        // linking. Those archives are C++ and need libc++ for their runtime
+        // symbols (operator new, __cxa_guard_*, __cxa_pure_virtual). Homebrew's
+        // LLVM has libLLVM.dylib so it never hits this, but link libc++ here so
+        // building against a static LLVM works too.
+        println!("cargo:rustc-link-lib=dylib=c++");
+        println!("cargo:rustc-link-lib=dylib=c++abi");
         if let Ok(output) = std::process::Command::new("llvm-config").arg("--libdir").output() {
             if output.status.success() {
                 let libdir = String::from_utf8_lossy(&output.stdout).trim().to_string();


### PR DESCRIPTION
## Problem

Building `openvaf-r` on macOS against an official prebuilt LLVM (e.g. the `LLVM-*-macOS-ARM64.tar.xz` release tarballs) fails at the final link with:

```
ld: symbol(s) not found for architecture arm64
  "operator new(unsigned long, std::nothrow_t const&)"
  "___cxa_guard_acquire" / "___cxa_guard_release" / "___cxa_pure_virtual"
  ...
```

## Root cause

Those tarballs ship only static component libraries — there is no `libLLVM.dylib`. `mir_llvm` requests `llvm-sys` with the `prefer-dynamic` feature, so with no dylib present it falls back to linking the static archives. Those archives are C++ and need libc++/libc++abi for their runtime symbols, which the final link doesn't pull in.

Homebrew's LLVM ships `libLLVM.dylib`, so the macOS CI path never hits this.

## Fix

Link `c++` and `c++abi` in the existing `#[cfg(target_os = "macos")]` block of `openvaf-driver/build.rs`. This only affects the final binary link (no full rebuild), and is harmless when a dynamic `libLLVM` is used since those libs come in transitively anyway.

## Alternatives considered

Happy to switch to whichever you prefer:
- gate the extra libs on `llvm-config --shared-mode == static`, or
- document "use Homebrew LLVM on macOS" instead of changing the build.

## Testing

LLVM 21.1.6 official arm64 release (`LLVM-21.1.6-macOS-ARM64.tar.xz`), Apple Silicon. With this change `openvaf-r` builds cleanly and compiles `integration_tests/CCCS/cccs.va` to a valid arm64 `.osdi` exporting the expected `OSDI_*` symbols.
