### PR TITLE
Fix ceil(), hypot() and $clog2() codegen

### DIFF
--- a/integration_tests/MATH_INTRINSICS/math_intrinsics.va
+++ b/integration_tests/MATH_INTRINSICS/math_intrinsics.va
@@ -1,0 +1,46 @@
+`include "constants.vams"
+`include "disciplines.vams"
+
+// Exercises every math builtin that `Builder::intrinsic` routes to an LLVM
+// intrinsic or a libm symbol. Most of them were called by no other model in
+// the suite, so a missing or mis-declared entry in `CodegenCx::intrinsic`
+// stayed invisible until a user hit it: `ceil` aborted codegen outright and
+// `hypot` emitted a module that failed the LLVM verifier.
+//
+// Every argument is derived from a branch voltage, otherwise constant folding
+// would evaluate the call before it ever reaches codegen and the coverage
+// would be lost.
+module math_intrinsics(A, C);
+    inout A, C;
+    electrical A, C;
+
+    branch (A, C) br;
+
+    (*desc = "Output scale", units = "A/V"*) parameter real scale = 1.0 from (0:inf);
+
+    real x, unit, upper, acc;
+    integer ix;
+
+    analog begin
+        x = V(br);
+
+        // |unit| < 1 keeps asin/acos/atanh inside their domain
+        unit = x / sqrt(1.0 + x * x);
+        // upper >= 1 keeps ln/log/acosh inside theirs
+        upper = 1.0 + x * x;
+
+        acc = sqrt(upper) + exp(-upper) + ln(upper) + log(upper);
+        acc = acc + floor(x) + ceil(x);
+        acc = acc + sin(x) + cos(x) + tan(unit);
+        acc = acc + asin(unit) + acos(unit) + atan(x);
+        acc = acc + sinh(unit) + cosh(unit) + tanh(x);
+        acc = acc + asinh(x) + acosh(upper) + atanh(unit);
+        acc = acc + hypot(x, 1.0) + atan2(x, 1.0) + pow(upper, unit);
+
+        // real -> integer cast and $clog2 also resolve through the intrinsic path
+        ix = upper * 8.0;
+        acc = acc + $clog2(ix);
+
+        I(br) <+ scale * acc;
+    end
+endmodule

--- a/openvaf/hir_ty/src/builtin.rs
+++ b/openvaf/hir_ty/src/builtin.rs
@@ -187,7 +187,7 @@ bultins! {
     const fn REAL_INFO() -> Real;
     const fn REAL_MATH_1(Val(Real)) -> Real;
     const fn REAL_MATH_2(Val(Real),Val(Real)) -> Real;
-    const fn INT_MATH_2(Val(Integer),Val(Integer)) -> Integer;
+    const fn INT_MATH_1(Val(Integer)) -> Integer;
 
 
     VT = const {
@@ -431,7 +431,7 @@ copied_builtins! {
     FLOOR = REAL_MATH_1
     LN = REAL_MATH_1
     LOG = REAL_MATH_1
-    CLOG2 = INT_MATH_2
+    CLOG2 = INT_MATH_1
     LOG10 = REAL_MATH_1
     CEIL = REAL_MATH_1
     LIMEXP = REAL_MATH_1

--- a/openvaf/mir_llvm/src/builder.rs
+++ b/openvaf/mir_llvm/src/builder.rs
@@ -908,7 +908,8 @@ impl<'ll> Builder<'_, '_, 'll> {
             Opcode::Log => NonNull::from(self.intrinsic(args, "llvm.log10.f64")).as_ptr(),
             Opcode::Clog2 => {
                 let leading_zeros =
-                    NonNull::from(self.intrinsic(&[args[0], true.into()], "llvm.ctlz")).as_ptr();
+                    NonNull::from(self.intrinsic(&[args[0], true.into()], "llvm.ctlz.i32"))
+                        .as_ptr();
                 let total_bits = NonNull::from(self.cx.const_int(32)).as_ptr();
                 llvm_sys::core::LLVMBuildSub(self.llbuilder, total_bits, leading_zeros, UNNAMED)
             }

--- a/openvaf/mir_llvm/src/intrinsics.rs
+++ b/openvaf/mir_llvm/src/intrinsics.rs
@@ -37,7 +37,8 @@ impl<'a, 'll> CodegenCx<'a, 'll> {
         ifn!("llvm.log10.f64", fn(t_f64) -> t_f64);
         ifn!("llvm.log2.f64", fn(t_f64) -> t_f64);
         ifn!("llvm.floor.f64", fn(t_f64) -> t_f64);
-        ifn!("llvm.ctlz", fn(t_i32, t_bool) -> t_i32);
+        ifn!("llvm.ceil.f64", fn(t_f64) -> t_f64);
+        ifn!("llvm.ctlz.i32", fn(t_i32, t_bool) -> t_i32);
 
         // not technically intrinsics but part of the C standard library
         // TODO link custom mathematical functions
@@ -56,7 +57,7 @@ impl<'a, 'll> CodegenCx<'a, 'll> {
 
         if name == "hypot" {
             let name = if self.target.options.is_like_windows { "_hypot" } else { "hypot" };
-            return Some(self.insert_intrinsic(name, &[t_f64], t_f64, false));
+            return Some(self.insert_intrinsic(name, &[t_f64, t_f64], t_f64, false));
         }
 
         ifn!("strcmp", fn(t_str, t_str) -> t_i32);

--- a/openvaf/test_data/osdi/math_intrinsics.snap
+++ b/openvaf/test_data/osdi/math_intrinsics.snap
@@ -1,0 +1,14 @@
+param "$mfactor"
+units = "", desc = "Multiplier (Verilog-A $mfactor)", flags = ParameterFlags(PARA_KIND_INST)
+param "scale"
+units = "A/V", desc = "Output scale", flags = ParameterFlags(0x0)
+
+2 terminals
+node "A" units = "V", runits = "A"
+node "C" units = "V", runits = "A"
+jacobian (A, A) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (A, C) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (C, A) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (C, C) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+0 states
+has bound_step false


### PR DESCRIPTION
Three math builtins — `ceil()`, `hypot()` and `$clog2()` — cannot be used at all on `mob`. This is independent of the VAMS-2023 work in #19; I found it while checking that my own new builtins were declared correctly in `CodegenCx::intrinsic`, and it's the same root cause I flagged in #20, so I'd suggest taking this one first.

Each fails differently, but all three for one reason: no model in the suite calls them, so the code path is never executed in CI.

## What happens today

Minimal model, `ceil`:

```
error: internal error: entered unreachable code: intrinsic llvm.ceil.f64 not found
```

`Opcode::Ceil` requests `llvm.ceil.f64`, but it was never declared alongside `llvm.floor.f64`, and `Builder::intrinsic` turns a missing declaration into `unreachable!()`.

`hypot`:

```
Incorrect number of arguments passed to called function!
  %60 = call double @hypot(double %25, double %29)
```

It is declared `double(double)` while `Opcode::Hypot` passes two arguments, so the module fails the LLVM verifier.

`$clog2` is broken twice over. The spec-conformant single-argument call is rejected up front:

```
error: invalid argument count: expected 2 arguments but found 1
```

because it is typed `INT_MATH_2`. Passing two arguments gets past the type checker and then silently discards the second, since `hir_lower` only reads `args[0]`. Fixing the signature then exposes the second problem:

```
Intrinsic name not mangled correctly for type arguments! Should be: llvm.ctlz.i32
ptr @llvm.ctlz
```

`ctlz` is overloaded, so it must carry the type suffix.

## The fix

Four small changes: declare `llvm.ceil.f64`, give `hypot` its second parameter, retype `$clog2` to one integer argument, and use the mangled `llvm.ctlz.i32`. `INT_MATH_2` had no other user, so it becomes `INT_MATH_1` rather than adding a second signature next to it.

## Why a new integration model

I'd rather not fix these and leave the next one to be found by a user, so this adds `MATH_INTRINSICS`, which calls every builtin that `Builder::intrinsic` routes to an LLVM intrinsic or a libm symbol.

Two things it has to get right to be worth anything:

- **arguments derive from a branch voltage.** With literal arguments, constant folding evaluates the call and codegen never sees it, so the model would pass whether or not the declarations are correct.
- **arguments stay in domain** — `unit = x/sqrt(1+x²)` for `asin`/`acos`/`atanh`, `upper = 1+x²` for `ln`/`log`/`acosh` — so the test fails on a real codegen problem rather than on a `NaN`.

Reverting any one of the four fixes makes it fail.

## Testing

Against LLVM 18.1.8:

- `cargo test -p osdi` — 27/27 (26 existing models plus the new one)
- `cargo test -p openvaf --test integration` — 71/71, which compiles the new model to a shared library, `dlopen`s it and processes its parameters
- full workspace, `RUN_SLOW_TESTS=1 RUN_DEV_TESTS=1` — green
- `cargo fmt --all -- --check` — clean

Two pre-existing failures are unrelated and reproduce on a clean `mob` checkout: `sourcegen osdi::gen_osdi_structs` panics at `sourcegen/src/osdi.rs:200`, and the `verilogae` crate does not compile (`CallBackKind::QueryPastState` no longer exists). Neither is built by `rust-ci.yml`.

One note on scope: `$clog2` now type-checks one argument, so any model that was passing two to work around the old signature would start erroring. That code was already getting its second argument ignored, so it cannot have been relied on for anything.
