### PR TITLE
Give cross()/above()/timer()/absdelta() real signatures (VAMS-2023 §5.10.3, Mantis 7810)

### DIFF
--- a/integration_tests/VAMS2023_EVENT_FUNS/vams2023_event_funs.va
+++ b/integration_tests/VAMS2023_EVENT_FUNS/vams2023_event_funs.va
@@ -1,0 +1,54 @@
+// VAMS-2023 5.10.3: the analog event functions
+//
+//   5.10.3.1  cross    ( expr [ , dir [ , time_tol [ , expr_tol [ , enable ] ] ] ] )
+//   5.10.3.2  above    ( expr [ , time_tol [ , expr_tol [ , enable ] ] ] )
+//   5.10.3.3  timer    ( start_time [ , period [ , time_tol [ , enable ] ] ] )
+//   5.10.3.4  absdelta ( expr , delta [ , time_tol [ , expr_tol [ , enable ] ] ] )
+//
+// Every argument is an `analog_expression`; the tolerances in particular are not
+// required to be constants and the LRM explicitly allows them to change during
+// the simulation. This model computes all of them at run time.
+//
+// The event condition does not take part in scheduling in OpenVAF (the guarded
+// body is always evaluated, see `hir_lower`'s `EventControl`), so the point of
+// this model is that the whole set compiles end to end -- the arguments are what
+// is being checked.
+`include "disciplines.vams"
+
+module vams2023_event_funs(d, q);
+    inout d, q;
+    electrical d, q;
+
+    parameter real thresh = 0.5;
+    parameter real period = 1e-9 from (0.0:inf);
+    parameter real vdelta = 0.1 from (0.0:inf);
+
+    integer dir;
+    integer enable;
+    real ttol;
+    real vtol;
+    real state;
+
+    analog begin
+        // all of these are dynamic expressions, not constants
+        dir = (V(d) > thresh) ? 1 : -1;
+        enable = 1;
+        ttol = period / 100.0;
+        vtol = vdelta / 100.0;
+
+        state = 0.0;
+
+        @(cross(V(d) - thresh, dir, ttol, vtol, enable)) state = state + 1.0;
+        @(above(V(d) - thresh, ttol, vtol, enable)) state = state + 2.0;
+        @(timer(0.0, period, ttol, enable)) state = state + 4.0;
+        @(absdelta(V(d), vdelta, ttol, vtol, enable)) state = state + 8.0;
+
+        // shorter arities of the same four functions
+        @(cross(V(d) - thresh)) state = state + 16.0;
+        @(above(V(d) - thresh)) state = state + 32.0;
+        @(timer(0.0)) state = state + 64.0;
+        @(absdelta(V(d), vdelta)) state = state + 128.0;
+
+        I(q) <+ V(q) - state;
+    end
+endmodule

--- a/openvaf/hir_def/src/body/lower.rs
+++ b/openvaf/hir_def/src/body/lower.rs
@@ -198,11 +198,17 @@ impl LowerCtx<'_> {
             // A bare path is a named event (VAMS-2023 5.10.4); everything else is a
             // monitored event (`@(cross(...))` / `@(timer(...))`), preserved so MIR
             // lowering can give the variables it assigns cross-timestep retention.
+            //
+            // A call is collected as well, so that the event function and its
+            // arguments are name-resolved and type-checked (VAMS-2023 5.10.3).
             let event = match event_stmt.event() {
                 Some(ast::Expr::PathExpr(path)) => {
                     Event::Named { event: self.collect_expr(ast::Expr::PathExpr(path)) }
                 }
-                _ => Event::Cross,
+                Some(call @ ast::Expr::Call(_)) => {
+                    Event::Cross { call: Some(self.collect_expr(call)) }
+                }
+                _ => Event::Cross { call: None },
             };
             let body = self.collect_opt_stmt(event_stmt.stmt());
             let stmt = Stmt::EventControl { event, body };

--- a/openvaf/hir_def/src/builtin.rs
+++ b/openvaf/hir_def/src/builtin.rs
@@ -127,6 +127,10 @@ pub enum BuiltIn {
     last_crossing = 112u8,
     slew = 113u8,
     transition = 114u8,
+    cross = 115u8,
+    above = 116u8,
+    timer = 117u8,
+    absdelta = 118u8,
 }
 #[derive(Eq, PartialEq, Copy, Clone, Hash, Debug)]
 #[allow(nonstandard_style, unreachable_pub)]
@@ -226,6 +230,15 @@ impl BuiltIn {
             | BuiltIn::rdist_erlang
             | BuiltIn::rdist_normal
             | BuiltIn::rdist_t => true,
+            _ => false,
+        }
+    }
+    #[doc = r" VAMS-2023 5.10.3: an analog event function, only valid as the"]
+    #[doc = r" event expression of an event control (`@(cross(...))`)."]
+    #[allow(clippy::match_like_matches_macro)]
+    pub fn is_event_fun(self) -> bool {
+        match self {
+            BuiltIn::cross | BuiltIn::above | BuiltIn::timer | BuiltIn::absdelta => true,
             _ => false,
         }
     }
@@ -383,6 +396,10 @@ pub fn insert_builtin_scope(dst: &mut IndexMap<Name, ScopeDefItem, BuildHasherDe
     dst.insert(kw::last_crossing, BuiltIn::last_crossing.into());
     dst.insert(kw::slew, BuiltIn::slew.into());
     dst.insert(kw::transition, BuiltIn::transition.into());
+    dst.insert(kw::cross, BuiltIn::cross.into());
+    dst.insert(kw::above, BuiltIn::above.into());
+    dst.insert(kw::timer, BuiltIn::timer.into());
+    dst.insert(kw::absdelta, BuiltIn::absdelta.into());
 }
 pub fn insert_module_builtin_scope(
     dst: &mut IndexMap<Name, ScopeDefItem, BuildHasherDefault<FxHasher>>,

--- a/openvaf/hir_def/src/expr.rs
+++ b/openvaf/hir_def/src/expr.rs
@@ -195,7 +195,15 @@ pub enum Event {
     },
     /// A monitored analog event such as `@(cross(...))` / `@(timer(...))`. Variables
     /// assigned inside its body are given cross-timestep retention during lowering.
-    Cross,
+    ///
+    /// `call` is the event-function call expression (VAMS-2023 5.10.3), collected so
+    /// that its arguments are name-resolved and type-checked. It is `None` when the
+    /// event expression was missing or was not a call. The call itself is never
+    /// lowered: the event condition does not take part in scheduling, the guarded
+    /// body is always evaluated (see `hir_lower`'s `EventControl`).
+    Cross {
+        call: Option<ExprId>,
+    },
     /// A named event (VAMS-2023 5.10.4): `@(ana_event)`. `event` is the path
     /// expression naming the event.
     Named {
@@ -220,11 +228,11 @@ impl Stmt {
     pub fn walk_child_exprs(&self, mut f: impl FnMut(ExprId)) {
         match *self {
             Stmt::Empty | Stmt::Missing | Stmt::Block { .. } | Stmt::Break | Stmt::Continue => (),
-            Stmt::EventControl { ref event, .. } => {
-                if let Event::Named { event } = *event {
-                    f(event)
-                }
-            }
+            Stmt::EventControl { ref event, .. } => match *event {
+                Event::Named { event } => f(event),
+                Event::Cross { call: Some(call) } => f(call),
+                _ => (),
+            },
             Stmt::EventTrigger { event } => f(event),
             Stmt::If { cond: expr, .. }
             | Stmt::ForLoop { cond: expr, .. }

--- a/openvaf/hir_lower/src/body.rs
+++ b/openvaf/hir_lower/src/body.rs
@@ -104,7 +104,7 @@ impl<'c1, 'c2> BodyLoweringCtx<'_, 'c1, 'c2> {
             | Stmt::EventTrigger { .. } => {}
             Stmt::Break | Stmt::Continue | Stmt::Return { .. } => {}
             Stmt::EventControl { event, body } => {
-                let inner = in_cross || matches!(event, Event::Cross);
+                let inner = in_cross || matches!(event, Event::Cross { .. });
                 self.collect_cross_assigned(body, inner, dst);
             }
             Stmt::Block { body } => {

--- a/openvaf/hir_ty/src/builtin.rs
+++ b/openvaf/hir_ty/src/builtin.rs
@@ -283,6 +283,44 @@ bultins! {
         fn LAST_CROSSING_DIRECTION(Val(Real),Val(Integer)) -> Real;
     }
 
+    // VAMS-2023 5.10.3 — the analog event functions. Every argument is an
+    // `analog_expression`, so none of them (in particular none of the tolerances)
+    // has to be a constant expression; the LRM explicitly permits `time_tol` and
+    // `expr_tol` to change during the simulation.
+
+    // 5.10.3.1: cross ( expr [ , dir [ , time_tol [ , expr_tol [ , enable ] ] ] ] )
+    CROSS = const {
+        fn CROSS_EXPR(Val(Real)) -> Bool;
+        fn CROSS_DIR(Val(Real),Val(Integer)) -> Bool;
+        fn CROSS_DIR_TTOL(Val(Real),Val(Integer),Val(Real)) -> Bool;
+        fn CROSS_DIR_TTOL_ETOL(Val(Real),Val(Integer),Val(Real),Val(Real)) -> Bool;
+        fn CROSS_DIR_TTOL_ETOL_ENABLE(Val(Real),Val(Integer),Val(Real),Val(Real),Val(Integer)) -> Bool;
+    }
+
+    // 5.10.3.2: above ( expr [ , time_tol [ , expr_tol [ , enable ] ] ] )
+    ABOVE = const {
+        fn ABOVE_EXPR(Val(Real)) -> Bool;
+        fn ABOVE_TTOL(Val(Real),Val(Real)) -> Bool;
+        fn ABOVE_TTOL_ETOL(Val(Real),Val(Real),Val(Real)) -> Bool;
+        fn ABOVE_TTOL_ETOL_ENABLE(Val(Real),Val(Real),Val(Real),Val(Integer)) -> Bool;
+    }
+
+    // 5.10.3.3: timer ( start_time [ , period [ , time_tol [ , enable ] ] ] )
+    TIMER = const {
+        fn TIMER_START(Val(Real)) -> Bool;
+        fn TIMER_START_PERIOD(Val(Real),Val(Real)) -> Bool;
+        fn TIMER_START_PERIOD_TTOL(Val(Real),Val(Real),Val(Real)) -> Bool;
+        fn TIMER_START_PERIOD_TTOL_ENABLE(Val(Real),Val(Real),Val(Real),Val(Integer)) -> Bool;
+    }
+
+    // 5.10.3.4: absdelta ( expr , delta [ , time_tol [ , expr_tol [ , enable ] ] ] )
+    ABSDELTA = const {
+        fn ABSDELTA_DELTA(Val(Real),Val(Real)) -> Bool;
+        fn ABSDELTA_DELTA_TTOL(Val(Real),Val(Real),Val(Real)) -> Bool;
+        fn ABSDELTA_DELTA_TTOL_ETOL(Val(Real),Val(Real),Val(Real),Val(Real)) -> Bool;
+        fn ABSDELTA_DELTA_TTOL_ETOL_ENABLE(Val(Real),Val(Real),Val(Real),Val(Real),Val(Integer)) -> Bool;
+    }
+
     fn BASIC_IO(Val(Integer)) -> Integer;
 
      FOPEN = {

--- a/openvaf/hir_ty/src/builtin/generated.rs
+++ b/openvaf/hir_ty/src/builtin/generated.rs
@@ -4,7 +4,7 @@ use hir_def::BuiltIn;
 
 use crate::builtin::*;
 
-const BUILTIN_INFO: [BuiltinInfo; 115usize] = [
+const BUILTIN_INFO: [BuiltinInfo; 119usize] = [
     ABS,
     ACOS,
     ACOSH,
@@ -120,5 +120,9 @@ const BUILTIN_INFO: [BuiltinInfo; 115usize] = [
     LAST_CROSSING,
     SLEW,
     TRANSITION,
+    CROSS,
+    ABOVE,
+    TIMER,
+    ABSDELTA,
 ];
 pub(crate) fn builtin_info(builtin: BuiltIn) -> BuiltinInfo { BUILTIN_INFO[builtin as u8 as usize] }

--- a/openvaf/hir_ty/src/inference.rs
+++ b/openvaf/hir_ty/src/inference.rs
@@ -183,6 +183,12 @@ impl Ctx<'_> {
                     self.expect::<false>(event, None, ty, Cow::Borrowed(&[TyRequirement::Event]));
                 }
             }
+            // VAMS-2023 5.10.3: `@(cross(...))` and friends. Inferring the call
+            // checks the event function's arguments; the result is discarded
+            // because the event expression is never lowered.
+            Stmt::EventControl { event: Event::Cross { call: Some(call) }, .. } => {
+                self.infere_expr(stmt, call);
+            }
             Stmt::Return { value: Some(value) } => {
                 let dst_ty = self.fn_return_ty.clone();
                 self.infere_assignment(stmt, value, dst_ty);
@@ -1131,10 +1137,17 @@ impl Ctx<'_> {
                         .map_or(false, |req| ty.satisfies_with_conversion(req))
                 });
                 if new_candidates.is_empty() {
-                    let candidate_types: Vec<TyRequirement> = candidates
-                        .iter()
-                        .filter_map(|candidate| signatures[*candidate].args.get(i).cloned())
-                        .collect();
+                    let mut candidate_types: Vec<TyRequirement> = Vec::new();
+                    for candidate in &candidates {
+                        if let Some(req) = signatures[*candidate].args.get(i) {
+                            // Several signatures usually agree on a given argument
+                            // (all five `cross` forms take a real `expr` first);
+                            // listing that requirement once reads far better.
+                            if !candidate_types.contains(req) {
+                                candidate_types.push(req.clone());
+                            }
+                        }
+                    }
                     debug_assert_ne!(&candidate_types, &[]);
                     errors.push(TypeMismatch {
                         expected: Cow::from(candidate_types),

--- a/openvaf/hir_ty/src/validation.rs
+++ b/openvaf/hir_ty/src/validation.rs
@@ -357,6 +357,12 @@ impl Diagnostic for BodyValidationDiagnosticWrapped<'_> {
                         "analysis function '{}' is not allowed in constants",
                         name
                     )),
+                    IllegalCtxAccessKind::EventFun { name } => res
+                        .with_message(format!("event function '{}' is not allowed here", name))
+                        .with_notes(vec![format!(
+                            "help: '{}' may only be used as the event expression of an event control, as in `@({}(...))`",
+                            name, name
+                        )]),
                     IllegalCtxAccessKind::Var(var) => {
                         let name = var.lookup(self.db.upcast()).name(self.db.upcast());
                         let def = var.lookup(self.db.upcast()).ast_ptr(self.db.upcast()).range();

--- a/openvaf/hir_ty/src/validation/body.rs
+++ b/openvaf/hir_ty/src/validation/body.rs
@@ -3,8 +3,8 @@ use std::mem::replace;
 use ahash::{HashMap, HashSet};
 use hir_def::body::Body;
 use hir_def::{
-    BranchId, BuiltIn, DefWithBodyId, DisciplineId, Expr, ExprId, FunctionArgLoc, Literal, Lookup,
-    ModuleBodyKind, NatureId, NodeId, ParamId, Path, Stmt, StmtId, VarId,
+    expr::Event, BranchId, BuiltIn, DefWithBodyId, DisciplineId, Expr, ExprId, FunctionArgLoc,
+    Literal, Lookup, ModuleBodyKind, NatureId, NodeId, ParamId, Path, Stmt, StmtId, VarId,
 };
 use stdx::impl_display;
 use syntax::ast::AssignOp;
@@ -19,11 +19,13 @@ use crate::inference::{BranchWrite, InferenceResult, ResolvedFun};
 use crate::lower::BranchKind;
 use crate::types::{Signature, Ty};
 
+// `EventFun` is an analog event function used outside `@(...)` (VAMS-2023 5.10.3).
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub enum IllegalCtxAccessKind {
     NatureAccess,
     AnalogOperator { name: Name, is_standard: bool, non_const_dominator: Box<[ExprId]> },
     AnalysisFun { name: Name },
+    EventFun { name: Name },
     Var(VarId),
 }
 
@@ -166,6 +168,7 @@ impl BodyValidationDiagnostic {
             diagnostics: Vec::new(),
             ctx,
             in_event_control: false,
+            event_call: None,
             non_const_dominator: Box::default(),
             non_trivial_branches: HashSet::default(),
             trivial_probes: HashMap::default(),
@@ -247,6 +250,10 @@ struct BodyValidator<'a> {
     /// Whether the statement being validated is (transitively) the body of an
     /// event control. Unlike `ctx` this survives entering a conditional.
     in_event_control: bool,
+    /// The event-function call an event control is currently being validated for.
+    /// An event function is legal at exactly this expression and nowhere else
+    /// (VAMS-2023 5.10.3), so a nested `@(cross(cross(...)))` is still rejected.
+    event_call: Option<ExprId>,
     non_const_dominator: Box<[ExprId]>,
     non_trivial_branches: HashSet<BranchWrite>,
     trivial_probes: HashMap<BranchWrite, Vec<(StmtId, ExprId)>>,
@@ -279,9 +286,20 @@ impl BodyValidator<'_> {
 
                 return;
             }
-            Stmt::EventControl { body, .. } => {
+            Stmt::EventControl { ref event, body } => {
+                let call = match *event {
+                    Event::Cross { call } => call,
+                    _ => None,
+                };
                 let old = replace(&mut self.ctx, BodyCtx::EventControl);
                 let old_event = replace(&mut self.in_event_control, true);
+                // The event expression is validated in the event context too: it may
+                // read natures (`@(cross(V(a)))`) but not use analog operators.
+                if let Some(call) = call {
+                    let old_call = replace(&mut self.event_call, Some(call));
+                    self.validate_expr(call, stmt);
+                    self.event_call = old_call;
+                }
                 self.validate_stmt(body);
                 self.in_event_control = old_event;
                 self.ctx = old;
@@ -699,6 +717,19 @@ impl ExprValidator<'_, '_> {
                     },
                     expr,
                     self.parent.ctx.allow_analog_operator(),
+                )
+            }
+
+            // VAMS-2023 5.10.3: event functions are not expressions; they may only
+            // appear as the event expression of an event control.
+            _ if call.is_event_fun() => {
+                let allowed = self.parent.event_call == Some(expr);
+                self.check_access(
+                    |_| IllegalCtxAccessKind::EventFun {
+                        name: name.as_ref().and_then(|p| p.as_ident()).unwrap(),
+                    },
+                    expr,
+                    allowed,
                 )
             }
 

--- a/openvaf/test_data/mir/named_events.mir
+++ b/openvaf/test_data/mir/named_events.mir
@@ -15,7 +15,7 @@ function %(v16, v17, v18, v19) {
 
                                 block4:
                                     v55 = phi [v5, block2], [v4, block3]
-@000c                               v21 = fgt v19, v20
+@000e                               v21 = fgt v19, v20
                                     br v21, block5, block6
 
                                 block5:
@@ -26,7 +26,7 @@ function %(v16, v17, v18, v19) {
 
                                 block7:
                                     v22 = phi [v2, block5], [v1, block6]
-@0013                               br v22, block8, block9
+@0017                               br v22, block8, block9
 
                                 block8:
                                     v34 = iadd v4, v5
@@ -37,7 +37,7 @@ function %(v16, v17, v18, v19) {
 
                                 block10:
                                     v63 = phi [v34, block8], [v4, block9]
-@0018                               br v2, block11, block12
+@001c                               br v2, block11, block12
 
                                 block11:
                                     v48 = iadd v4, v5

--- a/openvaf/test_data/osdi/vams2023_event_funs.snap
+++ b/openvaf/test_data/osdi/vams2023_event_funs.snap
@@ -1,0 +1,15 @@
+param "$mfactor"
+units = "", desc = "Multiplier (Verilog-A $mfactor)", flags = ParameterFlags(PARA_KIND_INST)
+param "thresh"
+units = "", desc = "", flags = ParameterFlags(0x0)
+param "period"
+units = "", desc = "", flags = ParameterFlags(0x0)
+param "vdelta"
+units = "", desc = "", flags = ParameterFlags(0x0)
+
+2 terminals
+node "d" units = "V", runits = "A"
+node "q" units = "V", runits = "A"
+jacobian (q, q) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+1 states
+has bound_step false

--- a/openvaf/test_data/ui/event_functions.va
+++ b/openvaf/test_data/ui/event_functions.va
@@ -1,0 +1,62 @@
+`include "disciplines.vams"
+
+// VAMS-2023 5.10.3: the analog event functions. Every argument is an
+// `analog_expression`, so all of the forms below -- including the ones whose
+// tolerances are variables rather than constants -- are legal.
+//
+//   5.10.3.1  cross    ( expr [ , dir [ , time_tol [ , expr_tol [ , enable ] ] ] ] )
+//   5.10.3.2  above    ( expr [ , time_tol [ , expr_tol [ , enable ] ] ] )
+//   5.10.3.3  timer    ( start_time [ , period [ , time_tol [ , enable ] ] ] )
+//   5.10.3.4  absdelta ( expr , delta [ , time_tol [ , expr_tol [ , enable ] ] ] )
+module event_functions(d, q);
+    inout d, q;
+    electrical d, q;
+
+    parameter real period = 1e-9;
+    parameter real delta = 0.1;
+
+    integer dir;
+    integer enable;
+    real ttol;
+    real etol;
+    real y;
+
+    analog begin
+        y = 0.0;
+        dir = 1;
+        enable = 1;
+        ttol = 1e-12;
+        etol = 1e-6;
+
+        // cross: all five arities
+        @(cross(V(d) - 0.5)) y = 1.0;
+        @(cross(V(d) - 0.5, +1)) y = 2.0;
+        @(cross(V(d) - 0.5, -1, ttol)) y = 3.0;
+        @(cross(V(d) - 0.5, dir, ttol, etol)) y = 4.0;
+        @(cross(V(d) - 0.5, dir, ttol, etol, enable)) y = 5.0;
+
+        // above: all four arities
+        @(above(V(d) - 2.5)) y = 6.0;
+        @(above(V(d) - 2.5, ttol)) y = 7.0;
+        @(above(V(d) - 2.5, ttol, etol)) y = 8.0;
+        @(above(V(d) - 2.5, ttol, etol, enable)) y = 9.0;
+
+        // timer: all four arities
+        @(timer(0.0)) y = 10.0;
+        @(timer(0.0, period)) y = 11.0;
+        @(timer(0.0, period, ttol)) y = 12.0;
+        @(timer(0.0, period, ttol, enable)) y = 13.0;
+
+        // absdelta: all four arities
+        @(absdelta(V(d), delta)) y = 14.0;
+        @(absdelta(V(d), delta, ttol)) y = 15.0;
+        @(absdelta(V(d), delta, ttol, etol)) y = 16.0;
+        @(absdelta(V(d), delta, ttol, etol, enable)) y = 17.0;
+
+        // integers convert to real where a real is expected, and vice versa
+        @(cross(V(d), 0, 1, 1)) y = 18.0;
+        @(timer(1, 2)) y = 19.0;
+
+        I(q) <+ y;
+    end
+endmodule

--- a/openvaf/test_data/ui/event_functions_err.log
+++ b/openvaf/test_data/ui/event_functions_err.log
@@ -1,0 +1,52 @@
+error: invalid argument count: expected at most 5 arguments but found 7
+   --> /event_functions_err.va:17:11
+   |
+17 |         @(cross(V(d), 1, 1e-12, 1e-6, 1, 7, 8)) y = 1.0;
+   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ expected at most 5 arguments
+
+error: invalid argument count: expected at least 1 arguments but found 0
+   --> /event_functions_err.va:20:11
+   |
+20 |         @(cross()) y = 2.0;
+   |           ^^^^^^^ expected at least 1 arguments
+
+error: invalid argument count: expected at least 2 arguments but found 1
+   --> /event_functions_err.va:21:11
+   |
+21 |         @(absdelta(V(d))) y = 3.0;
+   |           ^^^^^^^^^^^^^^ expected at least 2 arguments
+
+error: 'nonexistent_name' was not found in the current scope
+   --> /event_functions_err.va:24:17
+   |
+24 |         @(timer(nonexistent_name, also_bogus)) y = 4.0;
+   |                 ^^^^^^^^^^^^^^^^ not found
+
+error: 'also_bogus' was not found in the current scope
+   --> /event_functions_err.va:24:35
+   |
+24 |         @(timer(nonexistent_name, also_bogus)) y = 4.0;
+   |                                   ^^^^^^^^^^ not found
+
+error: type mismatch: expected real value but found string literal
+   --> /event_functions_err.va:27:17
+   |
+27 |         @(above("a string")) y = 5.0;
+   |                 ^^^^^^^^^^ expected real value
+
+error: event function 'cross' is not allowed here
+   --> /event_functions_err.va:30:13
+   |
+30 |         y = cross(V(d), 1);
+   |             ^^^^^^^^^^^^^^ not allowed here
+   |
+   = help: 'cross' may only be used as the event expression of an event control, as in `@(cross(...))`
+
+error: event function 'above' is not allowed here
+   --> /event_functions_err.va:33:17
+   |
+33 |         @(cross(above(V(d)))) y = 6.0;
+   |                 ^^^^^^^^^^^ not allowed here
+   |
+   = help: 'above' may only be used as the event expression of an event control, as in `@(above(...))`
+

--- a/openvaf/test_data/ui/event_functions_err.va
+++ b/openvaf/test_data/ui/event_functions_err.va
@@ -1,0 +1,37 @@
+`include "disciplines.vams"
+
+// VAMS-2023 5.10.3: the arguments of the analog event functions are now
+// name-resolved and type-checked. Before that, every call-shaped event
+// expression was dropped on the floor and all of the errors below compiled
+// with zero diagnostics.
+module event_functions_err(d, q);
+    inout d, q;
+    electrical d, q;
+
+    real y;
+
+    analog begin
+        y = 0.0;
+
+        // too many arguments (cross takes at most 5)
+        @(cross(V(d), 1, 1e-12, 1e-6, 1, 7, 8)) y = 1.0;
+
+        // not enough arguments
+        @(cross()) y = 2.0;
+        @(absdelta(V(d))) y = 3.0;
+
+        // unresolved names in the arguments
+        @(timer(nonexistent_name, also_bogus)) y = 4.0;
+
+        // wrong argument type
+        @(above("a string")) y = 5.0;
+
+        // an event function is not an expression (5.10.3)
+        y = cross(V(d), 1);
+
+        // ... not even nested inside another event function
+        @(cross(above(V(d)))) y = 6.0;
+
+        I(q) <+ y;
+    end
+endmodule

--- a/sourcegen/src/hir_builtins.rs
+++ b/sourcegen/src/hir_builtins.rs
@@ -78,6 +78,10 @@ const UNSUPPORTED: [&str; 48] = [
 
 const ANALOG_OPERATORS_SYSFUN: [&str; 1] = ["$limit"];
 
+// VAMS-2023 5.10.3: analog event functions. They are not analog operators and
+// may only appear as the event expression of an event control (`@(...)`).
+const EVENT_FUNS: [&str; 4] = ["cross", "above", "timer", "absdelta"];
+
 const ANALYSIS_FUNS: [&str; 6] =
     ["analysis", "ac_stim", "noise_table", "noise_table_log", "white_noise", "flicker_noise"];
 
@@ -219,6 +223,7 @@ fn generate_builtins() {
         .chain(ANALYSIS_FUNS)
         .chain(ANALOG_OPERATORS_SYSFUN)
         .chain(ANALOG_OPERATORS)
+        .chain(EVENT_FUNS)
         .map(|builtin| {
             let is_sysfun = builtin.starts_with('$');
 
@@ -239,6 +244,7 @@ fn generate_builtins() {
 
     let analysis_funs = ANALYSIS_FUNS.into_iter().map(|op| format_ident!("{}", op));
     let analog_operators = ANALOG_OPERATORS.into_iter().map(|op| format_ident!("{}", op));
+    let event_funs = EVENT_FUNS.into_iter().map(|op| format_ident!("{}", op));
     let unsupported = UNSUPPORTED.into_iter().map(|op| format_ident!("{}", op));
     let analog_operators_sysfun =
         ANALOG_OPERATORS_SYSFUN.into_iter().map(|op| format_ident!("{}", &op[1..]));
@@ -288,6 +294,16 @@ fn generate_builtins() {
             pub fn is_unsupported(self)->bool{
                 match self{
                     #(BuiltIn::#unsupported)|* =>true,
+                    _ => false
+                }
+            }
+
+            /// VAMS-2023 5.10.3: an analog event function, only valid as the
+            /// event expression of an event control (`@(cross(...))`).
+            #[allow(clippy::match_like_matches_macro)]
+            pub fn is_event_fun(self)->bool{
+                match self{
+                    #(BuiltIn::#event_funs)|* =>true,
                     _ => false
                 }
             }


### PR DESCRIPTION
Part of #19 (VAMS-2023 alignment). This is the remaining half of Mantis 7810 — #30 fixed `transition()`'s tolerances, this one gives the four analog event functions real signatures.

## The gap

`collect_event_stmt` collects a *bare path* event expression (the named-event case added in #29) but drops every **call-shaped** one into `_ => Event::Cross` without collecting it. The arguments of `cross`/`above`/`timer`/`absdelta` were therefore never name-resolved and never type-checked — the four names were not in scope at all, and the expressions inside `@(...)` reached no analysis. On current `mob` both of these compile with **zero diagnostics**:

```verilog
@(cross(1.0, 2, 3, 4, 5, 6, 7, 8)) y = 1.0;
@(timer(undeclared, bogus))        y = 2.0;
```

## What this changes

The four functions become real builtins with the VAMS-2023 §5.10.3.1–5.10.3.4 signatures:

```
cross    ( expr [ , dir [ , time_tol [ , expr_tol [ , enable ] ] ] ] )
above    ( expr [ , time_tol [ , expr_tol [ , enable ] ] ] )
timer    ( start_time [ , period [ , time_tol [ , enable ] ] ] )
absdelta ( expr , delta [ , time_tol [ , expr_tol [ , enable ] ] ] )
```

`dir` and `enable` are integers, everything else is real. Every argument is an `analog_expression`, so **none of the tolerances has to be a constant** — the LRM explicitly permits `time_tol` and `expr_tol` to change during the simulation (§5.10.3.3, §5.10.3.4). This matches the dynamic-tolerance rule #30 applied to `transition()`.

- `hir_def`: `Event::Cross` carries `call: Option<ExprId>`, and `collect_event_stmt` collects a call-shaped event expression (the shape #29 established for named events).
- `hir_ty`: the call is inferred, so arity, argument types and name resolution are all checked. The event expression is validated in the `EventControl` context, so it may read natures (`@(cross(V(a)))`) but not use analog operators.
- Event functions are not expressions (§5.10.3): using one anywhere other than as *the* event expression of an event control is now an error, including nested inside another event function.

The call is deliberately **never lowered**. The event condition still takes no part in scheduling — the guarded body is always evaluated, exactly as before — so this is a front-end-only change. The one snapshot that moved (`named_events.mir`) moved only in its `@XXXX` source-reference tags, by exactly the number of newly collected expressions; the instruction stream is byte-identical.

Also deduplicates the candidate list in the "type mismatch" diagnostic. With five `cross` signatures that all take a real first argument, the old code printed `expected real value, real value, real value or real value`; it now prints each distinct requirement once.

## Not in scope

Two pre-existing parser gaps are unchanged and still rejected, both of which predate this PR:

- `analog_expression_or_null` — the null-argument form, `cross(expr, dir, , , enable)`.
- `analog_event_expression or analog_event_expression` — `@(cross(...) or timer(...))`.

## Test plan

- New `ui/event_functions.va` — every arity of all four functions, with tolerances that are variables rather than constants, plus integer/real conversion cases. Compiles clean.
- New `ui/event_functions_err.va` + `.log` — too many arguments, too few arguments, unresolved names, wrong argument type, an event function used as an expression, and one nested inside another.
- New `integration_tests/VAMS2023_EVENT_FUNS` — all four functions, all arities, run-time tolerances, compiled end to end through OSDI.
- `cargo test -p hir -p hir_ty -p hir_def -p hir_lower -p basedb -p sourcegen -p preprocessor -p syntax -p parser -p tokens -p mir -p mir_autodiff -p mir_build -p mir_interpret -p mir_opt -p sim_back` — green.
- `cargo test --release -p openvaf-driver -p openvaf -p osdi -p mir_llvm --features llvm18` — green, including the behavioural `adc`, `cross_latch`, `cross_array` and `qam16` tests, whose `.snap` descriptors are unchanged.
- `RUN_DEV_TESTS=1` over the full integration suite — all 33 models (BSIM3/4/6, BSIMBULK/CMG/IMG/SOI, PSP102/103, HICUML2, HiSIM2/HV/SOTB, MEXTRAM, EKV, MVSG_CMC, DIODE_CMC, …) produce identical frontend diagnostics. This change can newly reject models that were passing garbage, so that sweep was the point; nothing regressed.
- `cargo fmt --all -- --check` — clean.
