### PR TITLE
release: ship the real libLLVM in the Linux tarball (currently a dangling symlink)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,29 @@ jobs:
         run: |
           set -euo pipefail
           PKG="openvaf-r-${RELEASE_TAG}-linux-x86_64"
+          LIBDIR="$(llvm-config-"$LLVM_VERSION" --libdir)"
           mkdir -p "dist/$PKG/bin" "dist/$PKG/lib"
           cp target/release/openvaf-r "dist/$PKG/bin/"
-          cp -a "$(llvm-config-"$LLVM_VERSION" --libdir)"/libLLVM*.so* "dist/$PKG/lib/"
+          cp -a "$LIBDIR"/libLLVM*.so* "dist/$PKG/lib/"
+          # apt.llvm.org's libdir provides libLLVM.so.* as symlinks into the
+          # system multiarch dir (../../x86_64-linux-gnu/...). `cp -a` keeps
+          # them as symlinks, so the tarball ships dangling links instead of
+          # the library and the packaged binary only runs on hosts that
+          # already have a system libLLVM of the right major version.
+          # Materialize links that point outside the package's lib dir with
+          # the real file; same-dir sibling links (libLLVM.so -> libLLVM.so.N)
+          # stay symlinks and become valid once their target is materialized.
+          find "dist/$PKG/lib" -xtype l | while read -r link; do
+            case "$(readlink "$link")" in
+              */*) cp --remove-destination \
+                     "$(readlink -f "$LIBDIR/$(basename "$link")")" "$link" ;;
+            esac
+          done
+          if find "dist/$PKG" -xtype l | grep -q .; then
+            echo "error: package contains broken symlinks:" >&2
+            find "dist/$PKG" -xtype l >&2
+            exit 1
+          fi
           patchelf --set-rpath '$ORIGIN/../lib' "dist/$PKG/bin/openvaf-r"
           ldd "dist/$PKG/bin/openvaf-r"
           tar -C dist -czf "$PKG.tar.gz" "$PKG"


### PR DESCRIPTION
## Problem

The Linux release tarball (`openvaf-r-v24.0.1mob-linux-x86_64.tar.gz`) does not actually contain libLLVM — only a dangling symlink where it should be:

```
$ tar -tzvf openvaf-r-v24.0.1mob-linux-x86_64.tar.gz
lrwxrwxrwx ... lib/libLLVM.so -> libLLVM.so.21.1
lrwxrwxrwx ... lib/libLLVM.so.21.1 -> ../../x86_64-linux-gnu/libLLVM.so.21.1   <-- points outside the archive
lrwxrwxrwx ... lib/libLLVM-21.so -> libLLVM.so.21.1
lrwxrwxrwx ... lib/libLLVM.so.1 -> libLLVM.so.21.1
-rwxr-xr-x ... 101379969 bin/openvaf-r
```

So on any host without a system libLLVM of the same major version (e.g. stock Ubuntu 24.04, which packages LLVM 18–20), the binary fails despite the `$ORIGIN/../lib` RUNPATH:

```
$ bin/openvaf-r --version
error while loading shared libraries: libLLVM.so.21.1: cannot open shared object file: No such file or directory
```

## Cause

In the `Package` step of `release.yml`, `cp -a` copies `libLLVM*.so*` from `llvm-config --libdir` preserving symlinks. On apt.llvm.org installs, `libLLVM.so.21.1` in that libdir is itself a symlink into the system multiarch directory (`../../x86_64-linux-gnu/libLLVM.so.21.1`), so the dangling link is copied into the package instead of the library. CI doesn't catch it because the runner *does* have the system library, so the dynamic loader falls back to it after the RUNPATH lookup misses.

## Fix

After the copy, materialize any symlink whose target points outside the package `lib/` with the real file (one full copy of libLLVM; same-directory sibling links like `libLLVM.so -> libLLVM.so.21.1` are kept as symlinks and become valid), then fail the build if any broken symlink remains in the package.

## Verification

- Reproduced the failure with the shipped v24.0.1mob tarball on Ubuntu 24.04 with no system LLVM 21.
- After replacing the dangling symlink with the real `libLLVM.so.21.1`, the same binary runs and correctly compiles the IHP SG13G2 PDK models (psp103/psp103_nqs/r3_cmc/mosvar), verified through to an ngspice-47 simulation.
- The materialize-and-check shell logic was tested standalone against a replica of the apt.llvm.org symlink layout: exactly one real copy of the library ends up in `lib/`, sibling symlinks stay intact, and zero broken links remain.

The macOS packaging already dereferences dependencies per-file and doesn't appear affected; the Windows step copies DLLs directly.
