### PR TITLE
bound_step: combine multiple calls with min instead of overwriting

### DIFF
--- a/openvaf/hir_lower/src/expr.rs
+++ b/openvaf/hir_lower/src/expr.rs
@@ -813,6 +813,17 @@ impl BodyLoweringCtx<'_, '_, '_> {
             }
             BuiltIn::bound_step => {
                 let step_size = self.lower_expr(args[0]);
+                // Each call bounds the step, so the effective bound is the smallest of
+                // them -- `$bound_step` is not an assignment. The place is only read
+                // back once an earlier call has declared it, so a module with a single
+                // call (the common case) lowers exactly as it did before.
+                let step_size = if self.ctx.get_place(PlaceKind::BoundStep).is_some() {
+                    let prev = self.ctx.use_place(PlaceKind::BoundStep);
+                    let smaller = self.ctx.ins().flt(step_size, prev);
+                    self.lower_select_with(smaller, |_| step_size, |_| prev)
+                } else {
+                    step_size
+                };
                 self.ctx.def_place(PlaceKind::BoundStep, step_size);
                 GRAVESTONE
             }

--- a/openvaf/test_data/mir/bound_step_min.mir
+++ b/openvaf/test_data/mir/bound_step_min.mir
@@ -1,0 +1,29 @@
+function %(v16, v17, v20) {
+    v18 = fconst 0x1.0000000000000p-1
+                                block0:
+@0006                               v19 = fgt v17, v18
+                                    br v19, block2, block3
+
+                                block2:
+@0008                               v22 = flt v20, v16
+@0008                               br v22, block5, block6
+
+                                block5:
+@0008                               jmp block7
+
+                                block6:
+@0008                               jmp block7
+
+                                block7:
+@0008                               v23 = phi [v20, block5], [v16, block6]
+                                    jmp block4
+
+                                block3:
+                                    jmp block4
+
+                                block4:
+                                    v30 = optbarrier v17
+                                    jmp block1
+
+                                block1:
+}

--- a/openvaf/test_data/mir/bound_step_min.va
+++ b/openvaf/test_data/mir/bound_step_min.va
@@ -1,0 +1,18 @@
+`include "disciplines.va"
+
+// Every `$bound_step` call bounds the time step, so the effective bound is the
+// smallest of them -- the call is not an assignment and a later call must not
+// discard an earlier, tighter bound. The second call here is conditional, so
+// the bound-step place also picks up a phi at the join.
+module test;
+    parameter real coarse = 1e-9;
+    parameter real fine = 1e-12;
+    electrical a;
+
+    analog begin
+        $bound_step(coarse);
+        if (V(a) > 0.5)
+            $bound_step(fine);
+        I(a) <+ V(a);
+    end
+endmodule


### PR DESCRIPTION
## The bug

`$bound_step` bounds the time step; it is not an assignment. When a module contains more than one call, the effective bound should be the smallest of them. Lowering wrote each call's argument straight into the `BoundStep` place, so **the last call won** and an earlier, tighter bound was silently discarded:

```verilog
analog begin
    $bound_step(fine);     // 1e-12
    $bound_step(coarse);   // 1e-9  -- overwrites the tighter bound
end
```

Two independent `$bound_step` calls in one module — or a user call alongside one inserted by a future event lowering — would let the simulator take a step that one of them had ruled out.

## The fix

`hir_lower` now reads the place back and keeps the smaller value, mirroring the existing `BuiltIn::min` lowering (`flt` + `lower_select_with`).

- The place is only read once an earlier call has declared it, so a module with a single `$bound_step` — the common case — lowers exactly as before. **No existing snapshot moves.**
- The `INFINITY` initialiser in `dec_place` already makes the first call's minimum a no-op.
- A call inside a conditional picks up a phi at the join.

ngspice consumes the value as a step ceiling in `OSDItrunc` (`src/osdi/osditrunc.c`), so the smaller bound is what reaches the simulator.

## Tests

New MIR snapshot `test_data/mir/bound_step_min.va`: two calls, the second conditional on a node voltage. The snapshot shows the `flt` / select / phi for the conditional call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXTzrarRpdGMgaWt89qpoM
