### PR TITLE
Warn when an event control does not schedule its event

### DIFF
--- a/integration_tests/VAMS2023_EVENTS/frontend.log
+++ b/integration_tests/VAMS2023_EVENTS/frontend.log
@@ -1,0 +1,13 @@
+warning[L018]: 'timer' does not schedule an event yet
+   --> /vams2023_events.va:24:9
+   |  
+24 | /         @(timer(period)) begin
+25 | |             if (r > 100.0)
+26 | |                 -> sample_event;
+27 | |         end
+   | \-----------^ body is evaluated unconditionally
+   |  
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+

--- a/integration_tests/VAMS2023_EVENT_FUNS/frontend.log
+++ b/integration_tests/VAMS2023_EVENT_FUNS/frontend.log
@@ -1,0 +1,80 @@
+warning[L018]: 'cross' does not schedule an event yet
+   --> /vams2023_event_funs.va:41:9
+   |
+41 |         @(cross(V(d) - thresh, dir, ttol, vtol, enable)) state = state + 1.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'above' does not schedule an event yet
+   --> /vams2023_event_funs.va:42:9
+   |
+42 |         @(above(V(d) - thresh, ttol, vtol, enable)) state = state + 2.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'timer' does not schedule an event yet
+   --> /vams2023_event_funs.va:43:9
+   |
+43 |         @(timer(0.0, period, ttol, enable)) state = state + 4.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'absdelta' does not schedule an event yet
+   --> /vams2023_event_funs.va:44:9
+   |
+44 |         @(absdelta(V(d), vdelta, ttol, vtol, enable)) state = state + 8.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'cross' does not schedule an event yet
+   --> /vams2023_event_funs.va:47:9
+   |
+47 |         @(cross(V(d) - thresh)) state = state + 16.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'above' does not schedule an event yet
+   --> /vams2023_event_funs.va:48:9
+   |
+48 |         @(above(V(d) - thresh)) state = state + 32.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'timer' does not schedule an event yet
+   --> /vams2023_event_funs.va:49:9
+   |
+49 |         @(timer(0.0)) state = state + 64.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'absdelta' does not schedule an event yet
+   --> /vams2023_event_funs.va:50:9
+   |
+50 |         @(absdelta(V(d), vdelta)) state = state + 128.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+

--- a/openvaf/basedb/src/lints.rs
+++ b/openvaf/basedb/src/lints.rs
@@ -181,5 +181,6 @@ pub mod builtin {
         pub const variant_const_simparam = LintData{default_lvl: Warn, documentation_id: 15};
         pub const port_without_direction = LintData{default_lvl: Deny, documentation_id: 16};
         pub const trivial_probe = LintData{default_lvl: Warn, documentation_id: 17};
+        pub const unscheduled_event = LintData{default_lvl: Warn, documentation_id: 18};
     }
 }

--- a/openvaf/hir_ty/src/validation.rs
+++ b/openvaf/hir_ty/src/validation.rs
@@ -1,5 +1,7 @@
 use basedb::diagnostics::{Diagnostic, Label, LabelStyle, Report};
-use basedb::lints::builtin::{const_simparam, trivial_probe, variant_const_simparam};
+use basedb::lints::builtin::{
+    const_simparam, trivial_probe, unscheduled_event, variant_const_simparam,
+};
 use basedb::lints::{self, Lint, LintSrc};
 use basedb::{AstIdMap, BaseDB, FileId};
 pub use body::BodyValidationDiagnostic;
@@ -130,6 +132,10 @@ impl Diagnostic for BodyValidationDiagnosticWrapped<'_> {
                 let src = self.body_sm.lint_src(stmt, trivial_probe);
                 Some((trivial_probe, src))
             }
+            BodyValidationDiagnostic::UnscheduledEvent { stmt, .. } => {
+                let src = self.body_sm.lint_src(stmt, unscheduled_event);
+                Some((unscheduled_event, src))
+            }
             _ => None,
         }
     }
@@ -244,6 +250,26 @@ impl Diagnostic for BodyValidationDiagnosticWrapped<'_> {
                         "help: in an analog block an event may only be triggered from an event \
                          statement such as '@(timer(1n)) -> ev;'"
                             .to_owned(),
+                    ])
+            }
+            BodyValidationDiagnostic::UnscheduledEvent { stmt, func } => {
+                let FileSpan { range, file } = self.parse.to_file_span(
+                    self.body_sm.stmt_map_back[stmt].as_ref().unwrap().range(),
+                    self.sm,
+                );
+
+                Report::warning()
+                    .with_message(format!("'{func:?}' does not schedule an event yet"))
+                    .with_labels(vec![Label {
+                        style: LabelStyle::Primary,
+                        file_id: file,
+                        range: range.into(),
+                        message: "body is evaluated unconditionally".to_owned(),
+                    }])
+                    .with_notes(vec![
+                        "the event expression is checked but takes no part in scheduling"
+                            .to_owned(),
+                        "the guarded statement runs on every evaluation, not per event".to_owned(),
                     ])
             }
             BodyValidationDiagnostic::WriteToInputArg { expr, arg } => {

--- a/openvaf/hir_ty/src/validation/body.rs
+++ b/openvaf/hir_ty/src/validation/body.rs
@@ -63,6 +63,14 @@ pub enum BodyValidationDiagnostic {
         ctx: BodyCtx,
     },
 
+    /// VAMS-2023 5.10.3: an analog event function is name-resolved and type-checked
+    /// but takes no part in scheduling yet, so the guarded statement is evaluated on
+    /// every evaluation of the analog block instead of only when the event occurs.
+    UnscheduledEvent {
+        stmt: StmtId,
+        func: BuiltIn,
+    },
+
     WriteToInputArg {
         expr: ExprId,
         arg: FunctionArgLoc,
@@ -299,6 +307,19 @@ impl BodyValidator<'_> {
                     let old_call = replace(&mut self.event_call, Some(call));
                     self.validate_expr(call, stmt);
                     self.event_call = old_call;
+
+                    // The event condition does not take part in scheduling yet (see
+                    // `hir_lower`'s `EventControl`): the guarded statement runs on
+                    // every evaluation. Warn instead of silently accepting a model
+                    // whose behaviour is not the one it describes.
+                    if let Some(ResolvedFun::BuiltIn(func)) = self.infer.resolved_calls.get(&call) {
+                        if func.is_event_fun() {
+                            self.diagnostics.push(BodyValidationDiagnostic::UnscheduledEvent {
+                                stmt,
+                                func: *func,
+                            });
+                        }
+                    }
                 }
                 self.validate_stmt(body);
                 self.in_event_control = old_event;

--- a/openvaf/test_data/mir/named_events.va
+++ b/openvaf/test_data/mir/named_events.va
@@ -1,7 +1,10 @@
 // VAMS-2023 5.10.4 (Mantis 7809): named events are declared with `event`,
 // triggered with `-> name;` from an analog event statement and detected with
 // `@(name)`.
-module named_events;
+// `@(timer(...))` is the only way to trigger a named event, and timer events are
+// not scheduled yet, so allow the warning: this test is about the named-event
+// lowering, not about the timer.
+(*openvaf_allow="unscheduled_event"*) module named_events;
     parameter real thresh = 0.5;
 
     event sampled;

--- a/openvaf/test_data/ui/event_functions.log
+++ b/openvaf/test_data/ui/event_functions.log
@@ -1,0 +1,190 @@
+warning[L018]: 'cross' does not schedule an event yet
+   --> /event_functions.va:32:9
+   |
+32 |         @(cross(V(d) - 0.5)) y = 1.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'cross' does not schedule an event yet
+   --> /event_functions.va:33:9
+   |
+33 |         @(cross(V(d) - 0.5, +1)) y = 2.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'cross' does not schedule an event yet
+   --> /event_functions.va:34:9
+   |
+34 |         @(cross(V(d) - 0.5, -1, ttol)) y = 3.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'cross' does not schedule an event yet
+   --> /event_functions.va:35:9
+   |
+35 |         @(cross(V(d) - 0.5, dir, ttol, etol)) y = 4.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'cross' does not schedule an event yet
+   --> /event_functions.va:36:9
+   |
+36 |         @(cross(V(d) - 0.5, dir, ttol, etol, enable)) y = 5.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'above' does not schedule an event yet
+   --> /event_functions.va:39:9
+   |
+39 |         @(above(V(d) - 2.5)) y = 6.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'above' does not schedule an event yet
+   --> /event_functions.va:40:9
+   |
+40 |         @(above(V(d) - 2.5, ttol)) y = 7.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'above' does not schedule an event yet
+   --> /event_functions.va:41:9
+   |
+41 |         @(above(V(d) - 2.5, ttol, etol)) y = 8.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'above' does not schedule an event yet
+   --> /event_functions.va:42:9
+   |
+42 |         @(above(V(d) - 2.5, ttol, etol, enable)) y = 9.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'timer' does not schedule an event yet
+   --> /event_functions.va:45:9
+   |
+45 |         @(timer(0.0)) y = 10.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'timer' does not schedule an event yet
+   --> /event_functions.va:46:9
+   |
+46 |         @(timer(0.0, period)) y = 11.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'timer' does not schedule an event yet
+   --> /event_functions.va:47:9
+   |
+47 |         @(timer(0.0, period, ttol)) y = 12.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'timer' does not schedule an event yet
+   --> /event_functions.va:48:9
+   |
+48 |         @(timer(0.0, period, ttol, enable)) y = 13.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'absdelta' does not schedule an event yet
+   --> /event_functions.va:51:9
+   |
+51 |         @(absdelta(V(d), delta)) y = 14.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'absdelta' does not schedule an event yet
+   --> /event_functions.va:52:9
+   |
+52 |         @(absdelta(V(d), delta, ttol)) y = 15.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'absdelta' does not schedule an event yet
+   --> /event_functions.va:53:9
+   |
+53 |         @(absdelta(V(d), delta, ttol, etol)) y = 16.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'absdelta' does not schedule an event yet
+   --> /event_functions.va:54:9
+   |
+54 |         @(absdelta(V(d), delta, ttol, etol, enable)) y = 17.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'cross' does not schedule an event yet
+   --> /event_functions.va:57:9
+   |
+57 |         @(cross(V(d), 0, 1, 1)) y = 18.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'timer' does not schedule an event yet
+   --> /event_functions.va:58:9
+   |
+58 |         @(timer(1, 2)) y = 19.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+

--- a/openvaf/test_data/ui/event_functions_err.log
+++ b/openvaf/test_data/ui/event_functions_err.log
@@ -34,6 +34,56 @@ error: type mismatch: expected real value but found string literal
 27 |         @(above("a string")) y = 5.0;
    |                 ^^^^^^^^^^ expected real value
 
+warning[L018]: 'cross' does not schedule an event yet
+   --> /event_functions_err.va:17:9
+   |
+17 |         @(cross(V(d), 1, 1e-12, 1e-6, 1, 7, 8)) y = 1.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'cross' does not schedule an event yet
+   --> /event_functions_err.va:20:9
+   |
+20 |         @(cross()) y = 2.0;
+   |         ^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'absdelta' does not schedule an event yet
+   --> /event_functions_err.va:21:9
+   |
+21 |         @(absdelta(V(d))) y = 3.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'timer' does not schedule an event yet
+   --> /event_functions_err.va:24:9
+   |
+24 |         @(timer(nonexistent_name, also_bogus)) y = 4.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'above' does not schedule an event yet
+   --> /event_functions_err.va:27:9
+   |
+27 |         @(above("a string")) y = 5.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
 error: event function 'cross' is not allowed here
    --> /event_functions_err.va:30:13
    |
@@ -49,4 +99,14 @@ error: event function 'above' is not allowed here
    |                 ^^^^^^^^^^^ not allowed here
    |
    = help: 'above' may only be used as the event expression of an event control, as in `@(above(...))`
+
+warning[L018]: 'cross' does not schedule an event yet
+   --> /event_functions_err.va:33:9
+   |
+33 |         @(cross(above(V(d)))) y = 6.0;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
 

--- a/openvaf/test_data/ui/named_events.log
+++ b/openvaf/test_data/ui/named_events.log
@@ -1,0 +1,23 @@
+warning[L018]: 'timer' does not schedule an event yet
+   --> /named_events.va:18:9
+   |
+18 |         @(timer(period)) -> ana_event;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'timer' does not schedule an event yet
+   --> /named_events.va:20:9
+   |  
+20 | /         @(timer(2.0 * period)) begin
+21 | |             -> other_event;
+22 | |             -> third_event;
+23 | |         end
+   | \-----------^ body is evaluated unconditionally
+   |  
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+

--- a/openvaf/test_data/ui/named_events_err.log
+++ b/openvaf/test_data/ui/named_events_err.log
@@ -24,3 +24,23 @@ error: event triggers are not allowed in analog block
    |
    = help: in an analog block an event may only be triggered from an event statement such as '@(timer(1n)) -> ev;'
 
+warning[L018]: 'timer' does not schedule an event yet
+   --> /named_events_err.va:15:9
+   |
+15 |         @(timer(1n)) -> not_an_event;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+
+warning[L018]: 'timer' does not schedule an event yet
+   --> /named_events_err.va:21:9
+   |
+21 |         @(timer(1n)) -> missing_event;
+   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
+   |
+   = the event expression is checked but takes no part in scheduling
+   = the guarded statement runs on every evaluation, not per event
+   = unscheduled_event is set to warn by default
+


### PR DESCRIPTION
Part of #19 (VAMS-2023 alignment). Follows up #31.

## The gap

Since #31, `cross`, `above`, `timer` and `absdelta` are name-resolved and type-checked (VAMS-2023 §5.10.3), but the call is deliberately never lowered: the event condition takes no part in scheduling, and the guarded statement is evaluated on **every** evaluation of the analog block. A model written against the LRM semantics therefore compiles without a single diagnostic and silently does something else:

```verilog
@(cross(V(d) - 0.7, +1)) count = count + 1;   // increments on every evaluation, not once per crossing
```

## What this changes

Adds an `unscheduled_event` lint (L018), **warn by default**, reported at the event control:

```
warning[L018]: 'cross' does not schedule an event yet
   --> /event_functions.va:32:9
   |
32 |         @(cross(V(d) - 0.5)) y = 1.0;
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ body is evaluated unconditionally
   |
   = the event expression is checked but takes no part in scheduling
   = the guarded statement runs on every evaluation, not per event
   = unscheduled_event is set to warn by default
```

Making it a lint rather than a hardcoded warning means it can be:

- silenced per statement or per module with `(*openvaf_allow="unscheduled_event"*)`, or
- escalated with `openvaf_deny` or from the CLI by anyone who would rather not compile such a model at all.

It is a warning and not an error because the feature is partly there: variables assigned inside a `@(cross)` body do retain their value across timesteps (`retained_states`), so a handler that guards its own body — as `test_data/osdi/cross_latch.va` does — still behaves as intended.

## Tests

- New/updated diagnostic snapshots: `test_data/ui/event_functions.log`, `event_functions_err.log`, `named_events.log`, `named_events_err.log`, and `integration_tests/VAMS2023_EVENTS` / `VAMS2023_EVENT_FUNS` `frontend.log`.
- `test_data/mir/named_events.va` allows the lint at module level: `@(timer(...))` is the only way to trigger a named event, and that test is about the named-event lowering rather than the timer. Its MIR snapshot is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXTzrarRpdGMgaWt89qpoM
