### PR TITLE
Implement the slew analog operator (VAMS-2023 4.5.9)

### DIFF
--- a/openvaf/hir_def/src/builtin.rs
+++ b/openvaf/hir_def/src/builtin.rs
@@ -195,7 +195,6 @@ impl BuiltIn {
             | BuiltIn::laplace_zd
             | BuiltIn::laplace_zp
             | BuiltIn::last_crossing
-            | BuiltIn::slew
             | BuiltIn::fclose
             | BuiltIn::fopen
             | BuiltIn::fdisplay

--- a/openvaf/hir_lower/src/expr.rs
+++ b/openvaf/hir_lower/src/expr.rs
@@ -940,7 +940,54 @@ impl BodyLoweringCtx<'_, '_, '_> {
                     x
                 }
             }
-            BuiltIn::slew | BuiltIn::limit => self.lower_expr(args[0]),
+            BuiltIn::slew => {
+                // VAMS-2023 4.5.9: `slew` bounds the rate of change of its argument.
+                //
+                //   slew ( expr [ , max_pos_slew_rate [ , max_neg_slew_rate ] ] )
+                //
+                // With no rates given the LRM passes the signal through unchanged,
+                // and in DC it passes the value through as well.
+                let target = self.lower_expr(args[0]);
+                if self.ctx.no_equations || args.len() == 1 {
+                    target
+                } else {
+                    let max_pos = self.lower_expr(args[1]);
+                    // "If the max_neg_slew_rate is not specified, it defaults to the
+                    // opposite of the max_pos_slew_rate."
+                    let max_neg = if args.len() > 2 {
+                        self.lower_expr(args[2])
+                    } else {
+                        self.ctx.ins().fneg(max_pos)
+                    };
+
+                    // Realized as a continuous rate limiter, the same shape as the
+                    // `transition` lag below: a state whose derivative chases the
+                    // target with a very large gain, clamped to the two rates. While
+                    // the input changes more slowly than the limits the state follows
+                    // it to within `eps * rate`, which is what the LRM asks for
+                    // ("returns the value of expr"); once a limit is reached the state
+                    // moves at exactly that rate. A clamped derivative is continuous
+                    // in time, so the transient integrator can step across it.
+                    let eps = self.ctx.fconst(1e-12);
+                    let (eq, x) =
+                        self.ctx.implicit_equation(ImplicitEquationKind::Idt(IdtKind::Basic));
+                    let diff = self.ctx.ins().fsub(target, x);
+                    let rate = self.ctx.ins().fdiv(diff, eps);
+                    // rate = min(max(rate, max_neg), max_pos)
+                    let too_fast = self.ctx.ins().fgt(rate, max_pos);
+                    let rate =
+                        self.ctx.make_select(too_fast, |_s, b| if b { max_pos } else { rate });
+                    let too_slow = self.ctx.ins().flt(rate, max_neg);
+                    let rate =
+                        self.ctx.make_select(too_slow, |_s, b| if b { max_neg } else { rate });
+                    // dx/dt = rate  ->  react = x, resist = -rate.
+                    let resist = self.ctx.ins().fneg(rate);
+                    self.ctx.def_resist_residual(resist, eq);
+                    self.ctx.def_react_residual(x, eq);
+                    x
+                }
+            }
+            BuiltIn::limit => self.lower_expr(args[0]),
 
             // `ac_stim` is an AC small-signal stimulus: it is defined to be zero in the
             // large-signal (DC/transient) domain, which is what a contribution lowers.

--- a/openvaf/hir_ty/src/builtin.rs
+++ b/openvaf/hir_ty/src/builtin.rs
@@ -259,6 +259,8 @@ bultins! {
         fn ABSDELAY_MAX(Val(Real), Val(Real), Val(Real)) -> Real;
     }
 
+    // VAMS-2023 4.5.9:
+    //   slew ( expr [ , max_pos_slew_rate [ , max_neg_slew_rate ] ] )
     SLEW = const {
         fn SLEW_NO_MAX(Val(Real)) -> Real;
         fn SLEW_POS_MAX(Val(Real),Val(Real)) -> Real;
@@ -266,7 +268,7 @@ bultins! {
     }
 
 
-    // VAMS-2023 4.5.9:
+    // VAMS-2023 4.5.8:
     //   transition ( expr [ , td [ , rise_time [ , fall_time [ , time_tol ] ] ] ] )
     // Every argument is a dynamic expression (Table 4-20, Mantis 7810).
     TRANSITION = const {

--- a/openvaf/openvaf/tests/integration.rs
+++ b/openvaf/openvaf/tests/integration.rs
@@ -505,6 +505,78 @@ fn test_adc() -> Result<()> {
     Ok(())
 }
 
+/// VAMS-2023 4.5.9: the rate-limited form of `slew` is realized as an implicit
+/// equation, the path the `mir` snapshot (lowered without equations) cannot reach.
+/// The equation is `dx/dt = clamp((expr - x)/eps, max_neg, max_pos)`, lowered as
+/// `react = x`, `resist = -rate`, so the resistive residual of the equation node
+/// *is* the negated slew rate and can be read directly. See `slew.va`.
+fn test_slew() -> Result<()> {
+    if stdx::IS_CI && cfg!(windows) {
+        return Ok(());
+    }
+
+    const MAX_POS: f64 = 1e6;
+    const MAX_NEG: f64 = -2e6;
+    // the gain the lowering chases the target with
+    const EPS: f64 = 1e-12;
+
+    let desc = test_descriptor(&openvaf_test_data("osdi").join("slew.va"))?;
+    let model = desc.new_model();
+    model.process_params()?;
+    let mut instance = model.new_instance();
+    let mut sim = instance.mock_simulation(&model, desc.num_terminals, 300.0)?;
+
+    // Evaluate with the input at `v_in` and the slew state at `x`, and return the
+    // (resistive, reactive) residual of the slew equation.
+    let eval = |instance: &OsdiInstance,
+                model: &OsdiModel,
+                sim: &mut MockSimulation,
+                v_in: f64,
+                x: f64,
+                first: bool| {
+        if !first {
+            sim.next_iter();
+        }
+        sim.set_voltage("in", v_in);
+        sim.set_voltage("out", 0.0);
+        sim.set_voltage("thru", 0.0);
+        sim.set_voltage("implicit_equation_0", x);
+        instance.eval(model, sim, EvalFlags::empty());
+        instance.load_dae(model, sim);
+        sim.read_residual("implicit_equation_0")
+    };
+
+    // Input far above the state: the rate saturates at max_pos, and the reactive
+    // residual is the state itself (the d/dt term).
+    let (resist, react) = eval(&instance, &model, &mut sim, 1.0, 0.0, true);
+    float_cmp::assert_approx_eq!(f64, resist, -MAX_POS, epsilon = 1e-6);
+    float_cmp::assert_approx_eq!(f64, react, 0.0, epsilon = 1e-9);
+
+    // Input far below the state: it saturates at max_neg, which is a different
+    // magnitude, so this also pins that the two limits are not interchanged.
+    let (resist, _) = eval(&instance, &model, &mut sim, -1.0, 0.0, false);
+    float_cmp::assert_approx_eq!(f64, resist, -MAX_NEG, epsilon = 1e-6);
+
+    // State already at the input: nothing to chase, so the rate is zero.
+    let (resist, react) = eval(&instance, &model, &mut sim, 0.5, 0.5, false);
+    float_cmp::assert_approx_eq!(f64, resist, 0.0, epsilon = 1e-9);
+    float_cmp::assert_approx_eq!(f64, react, 0.5, epsilon = 1e-9);
+
+    // Below the limits the rate is not clamped but follows the difference, which is
+    // what makes the state track the input rather than ramp at a fixed slope.
+    let delta = 1e-7;
+    let (resist, _) = eval(&instance, &model, &mut sim, delta, 0.0, false);
+    float_cmp::assert_approx_eq!(f64, resist, -delta / EPS, epsilon = 1e-3);
+
+    // The form with no rates is a plain pass-through. A voltage contribution puts
+    // its equation on the branch flow unknown, where it reads as
+    // `slew(V(in)) - V(thru)`, and `thru` gets no equation of its own: with
+    // `V(thru)` held at 0 the residual is the input itself.
+    float_cmp::assert_approx_eq!(f64, sim.read_residual("flow(thru)").0, delta, epsilon = 1e-12);
+
+    Ok(())
+}
+
 harness! {
     // TODO: run this in CI, somehow this test is flakey tough regarding the linker invocation (and really slow)
     Test::from_dir("integration", &integration_test, &ignore_dev_tests, &project_root().join("integration_tests")),
@@ -514,5 +586,5 @@ harness! {
     Test::from_dir_filtered("vacask_spice", &vacask_spice_test, &is_va_file, &ignore_dev_tests, &vacask_devices().join("spice")),
     // VACASK simplified SPICE models
     Test::from_dir_filtered("vacask_spice_sn", &vacask_spice_sn_test, &is_va_file, &ignore_dev_tests, &vacask_devices().join("spice/sn")),
-    [Test::new("$limit", &test_limit),Test::new("noise", &test_noise),Test::new("arrays", &test_arrays),Test::new("cross_latch", &test_cross_latch),Test::new("laplace_nd_int", &test_laplace_nd_int),Test::new("vector_ports", &test_vector_ports),Test::new("qam16", &test_qam16),Test::new("cross_array", &test_cross_array),Test::new("adc", &test_adc),Test::new("indirect_opamp", &test_indirect_opamp)]
+    [Test::new("$limit", &test_limit),Test::new("noise", &test_noise),Test::new("arrays", &test_arrays),Test::new("cross_latch", &test_cross_latch),Test::new("laplace_nd_int", &test_laplace_nd_int),Test::new("vector_ports", &test_vector_ports),Test::new("qam16", &test_qam16),Test::new("cross_array", &test_cross_array),Test::new("adc", &test_adc),Test::new("indirect_opamp", &test_indirect_opamp),Test::new("slew", &test_slew)]
 }

--- a/openvaf/test_data/mir/slew.mir
+++ b/openvaf/test_data/mir/slew.mir
@@ -1,0 +1,9 @@
+function %(v16, v17, v18) {
+block0:
+    v19 = optbarrier v16
+    v20 = optbarrier v17
+    v21 = optbarrier v18
+    jmp block1
+
+block1:
+}

--- a/openvaf/test_data/mir/slew.va
+++ b/openvaf/test_data/mir/slew.va
@@ -1,0 +1,26 @@
+`include "disciplines.vams"
+
+// VAMS-2023 4.5.9: `slew` bounds the rate of change of its argument.
+//
+//   slew ( expr [ , max_pos_slew_rate [ , max_neg_slew_rate ] ] )
+//
+// This harness lowers without equations, which is the domain the LRM describes
+// as "in DC analysis, slew() simply passes the value of the destination to its
+// output": every form below lowers to its first argument. The rate-limiting
+// realization is the DAE path, which needs `with_equations`.
+module slew_test(a, b, c);
+    inout a, b, c;
+    electrical a, b, c;
+
+    parameter real max_pos = 1e6;
+    parameter real max_neg = -2e6;
+
+    analog begin
+        // no rates: passes through in every domain
+        V(a) <+ slew(V(b));
+        // symmetric limit: max_neg defaults to -max_pos
+        V(b) <+ slew(V(c), max_pos);
+        // separate rise and fall limits
+        V(c) <+ slew(V(a), max_pos, max_neg);
+    end
+endmodule

--- a/openvaf/test_data/osdi/slew.snap
+++ b/openvaf/test_data/osdi/slew.snap
@@ -1,0 +1,24 @@
+param "$mfactor"
+units = "", desc = "Multiplier (Verilog-A $mfactor)", flags = ParameterFlags(PARA_KIND_INST)
+param "max_pos"
+units = "", desc = "", flags = ParameterFlags(0x0)
+param "max_neg"
+units = "", desc = "", flags = ParameterFlags(0x0)
+
+3 terminals
+node "in" units = "V", runits = "A"
+node "out" units = "V", runits = "A"
+node "thru" units = "V", runits = "A"
+node(flow) "flow(out)" units = "A", runits = "V"
+node(flow) "flow(thru)" units = "A", runits = "V"
+node "implicit_equation_0" units = "", runits = ""
+jacobian (out, flow(out)) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (thru, flow(thru)) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(out), out) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(out), implicit_equation_0) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(thru), in) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(thru), thru) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_0, in) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_0, implicit_equation_0) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT | JACOBIAN_ENTRY_REACT_CONST)
+0 states
+has bound_step false

--- a/openvaf/test_data/osdi/slew.va
+++ b/openvaf/test_data/osdi/slew.va
@@ -1,0 +1,20 @@
+`include "disciplines.vams"
+
+// VAMS-2023 4.5.9: `slew` bounds the rate of change of its argument. The
+// rate-limited form is realized as an implicit equation, so this model exercises
+// the DAE path that the `mir` snapshot (lowered without equations) cannot reach.
+module slew_osdi(in, out, thru);
+    input in;
+    output out, thru;
+    electrical in, out, thru;
+
+    parameter real max_pos = 1e6 from (0:inf);
+    parameter real max_neg = -2e6 from (-inf:0);
+
+    analog begin
+        // rate limited: introduces one implicit equation
+        V(out) <+ slew(V(in), max_pos, max_neg);
+        // no rates: passes through, no equation
+        V(thru) <+ slew(V(in));
+    end
+endmodule

--- a/openvaf/test_data/ui/slew.va
+++ b/openvaf/test_data/ui/slew.va
@@ -1,0 +1,26 @@
+`include "disciplines.vams"
+
+// VAMS-2023 4.5.9: `slew` is an analog operator, not an unsupported function.
+// All three forms are accepted, the rates may be dynamic expressions, and the
+// operator restrictions that apply to every analog operator still apply to it.
+module slew_ui(in, out);
+    input in;
+    output out;
+    electrical in, out;
+
+    parameter real max_pos = 1e6 from (0:inf);
+    parameter real max_neg = -1e6 from (-inf:0);
+
+    real rate;
+
+    analog begin
+        rate = max_pos * (1.0 + 0.1 * V(in));
+
+        V(out) <+ slew(V(in));
+        V(out) <+ slew(V(in), max_pos);
+        V(out) <+ slew(V(in), max_pos, max_neg);
+        // the rates are ordinary expressions, so they may vary during the
+        // simulation
+        V(out) <+ slew(V(in), rate);
+    end
+endmodule

--- a/sourcegen/src/hir_builtins.rs
+++ b/sourcegen/src/hir_builtins.rs
@@ -25,7 +25,7 @@ const ANALOG_OPERATORS: [&str; 17] = [
     "transition",
 ];
 
-const UNSUPPORTED: [&str; 48] = [
+const UNSUPPORTED: [&str; 47] = [
     "simprobe",
     "analog_node_alias",
     "analog_port_alias",
@@ -39,7 +39,6 @@ const UNSUPPORTED: [&str; 48] = [
     "laplace_zd",
     "laplace_zp",
     "last_crossing",
-    "slew",
     "fclose",
     "fopen",
     "fdisplay",


### PR DESCRIPTION
Part of #19 (VAMS-2023 alignment).

## The gap

`slew` (§4.5.9) is listed in `UNSUPPORTED`, so any model that bounds a slope with it is rejected outright:

```
error: function 'slew' is currently not supported by OpenVAF
```

The signatures were already declared (`SLEW_NO_MAX` / `SLEW_POS_MAX` / `SLEW_NEG_MAX`) and `hir_lower` already had an arm for it, passing the value straight through — dead code behind the `UNSUPPORTED` check.

## What this changes

`slew` comes off `UNSUPPORTED` and gets a real lowering:

- **No rates** — `slew(expr)` passes the signal through, which is what the LRM says ("If no rates are specified, slew() passes the signal through unchanged").
- **DC / no-equations** — passes the value through: "In DC analysis, slew() simply passes the value of the destination to its output."
- **One rate** — `max_neg_slew_rate` defaults to the opposite of `max_pos_slew_rate`, per §4.5.9.
- **Transient** — realized as a continuous rate limiter: a state whose derivative chases the target with a very large gain, clamped to the two rates. Below the limits the state follows the input to within `eps * rate` (the LRM's "returns the value of expr"); at the limits it moves at exactly that rate.

This is the same shape as the existing `transition` realization directly below it in `expr.rs` — an implicit equation with `react = x`, `resist = -rate` — and for the same reason: a clamped derivative is continuous in time, so the transient integrator can step across it, where an ideal slope discontinuity would stall it.

The rates are ordinary expressions, so they may vary during the simulation.

Also fixes a clause number in a comment: `transition` is §4.5.8, not §4.5.9.

## Tests

- **`openvaf/tests/integration.rs::test_slew`** — the DAE path, driven through the mock simulator. The lowering puts `resist = -rate` on the equation node, so the resistive residual *is* the negated slew rate and can be read directly. It pins: saturation at `max_pos` when the input is far above the state; saturation at `max_neg` when far below (a different magnitude, so the two limits cannot be silently interchanged); a zero rate once the state has caught up; and the unsaturated regime below the limits, which is what makes the state *track* the input instead of ramping at a fixed slope. It also checks that the no-rates form contributes a plain pass-through with no equation of its own.
- **`test_data/osdi/slew.snap`** — the descriptor: the rate-limited call creates `implicit_equation_0` with both resistive and reactive Jacobian entries (the `d/dt` term); the no-rates form creates none.
- **`test_data/ui/slew.va`** — all three forms plus a dynamic rate; compiles with no diagnostics, where every one of them was an error before.
- **`test_data/mir/slew.va`** — the MIR snapshot. Note this harness lowers *without* equations, so what it pins is the DC/pass-through behaviour, which is what the LRM prescribes for DC.

## Not in scope

`last_crossing` (§4.5.10) stays unsupported. It has to latch the interpolated time of a zero crossing across accepted timesteps, so it needs the crossing detection and previous-timestep state that monitored events need — the same work as event scheduling, tracked in #37.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXTzrarRpdGMgaWt89qpoM
