### PR TITLE
Implement laplace_zp/zd/np by expanding roots (VAMS-2023 4.5.11, Mantis 4848)

### DIFF
--- a/openvaf/hir_def/src/builtin.rs
+++ b/openvaf/hir_def/src/builtin.rs
@@ -191,9 +191,6 @@ impl BuiltIn {
             | BuiltIn::zi_np
             | BuiltIn::zi_zd
             | BuiltIn::zi_zp
-            | BuiltIn::laplace_np
-            | BuiltIn::laplace_zd
-            | BuiltIn::laplace_zp
             | BuiltIn::last_crossing
             | BuiltIn::slew
             | BuiltIn::fclose

--- a/openvaf/hir_lower/src/expr.rs
+++ b/openvaf/hir_lower/src/expr.rs
@@ -702,8 +702,20 @@ impl BodyLoweringCtx<'_, '_, '_> {
             }
 
             // Without equation lowering (e.g. op-var contexts) a filter is a no-op.
-            BuiltIn::laplace_nd if self.ctx.no_equations => F_ZERO,
+            BuiltIn::laplace_nd
+            | BuiltIn::laplace_zp
+            | BuiltIn::laplace_zd
+            | BuiltIn::laplace_np
+                if self.ctx.no_equations =>
+            {
+                F_ZERO
+            }
             BuiltIn::laplace_nd => self.lower_laplace_nd(args),
+            // VAMS-2023 4.5.11.1-4.5.11.3: the same filter with its numerator,
+            // denominator or both given as roots instead of coefficients.
+            BuiltIn::laplace_zp => self.lower_laplace_roots(args, true, true),
+            BuiltIn::laplace_zd => self.lower_laplace_roots(args, true, false),
+            BuiltIn::laplace_np => self.lower_laplace_roots(args, false, true),
 
             BuiltIn::idt => {
                 let kind = match_signature! {
@@ -1073,6 +1085,104 @@ impl BodyLoweringCtx<'_, '_, '_> {
         let input = self.lower_expr(args[0]);
         let num = self.array_coeffs(args[1]);
         let den = self.array_coeffs(args[2]);
+        self.lower_laplace_state_space(input, num, den)
+    }
+
+    /// Lower the root forms of the Laplace filter (VAMS-2023 4.5.11.1-4.5.11.3) by
+    /// expanding each root vector into polynomial coefficients and reusing the
+    /// `laplace_nd` realization. The number of roots is fixed at compile time (array
+    /// lengths are static), so only the coefficient arithmetic is emitted.
+    fn lower_laplace_roots(&mut self, args: &[ExprId], zeros: bool, poles: bool) -> Value {
+        let input = self.lower_expr(args[0]);
+        let num = if zeros {
+            let roots = self.array_coeffs(args[1]);
+            self.expand_roots(&roots)
+        } else {
+            self.array_coeffs(args[1])
+        };
+        let den = if poles {
+            let roots = self.array_coeffs(args[2]);
+            self.expand_roots(&roots)
+        } else {
+            self.array_coeffs(args[2])
+        };
+        self.lower_laplace_state_space(input, num, den)
+    }
+
+    /// Expand a flat vector of (real, imaginary) root pairs into the real polynomial
+    /// coefficients of `prod_k (1 - s/r_k)`, ascending powers of `s`.
+    ///
+    /// A root of zero contributes a bare `s` factor instead of `1 - s/r`, as
+    /// 4.5.11.1 requires. The LRM also requires a complex root's conjugate to be
+    /// present, which is what makes the product real: the expansion carries the
+    /// imaginary parts through and drops them at the end, so no case analysis on
+    /// whether a given root is real is needed -- which matters because the roots are
+    /// runtime values.
+    fn expand_roots(&mut self, roots: &[Value]) -> Vec<Value> {
+        let one = self.ctx.fconst(1.0);
+        // running polynomial, real and imaginary parts, ascending powers of s
+        let mut re = vec![one];
+        let mut im = vec![F_ZERO];
+
+        for pair in roots.chunks(2) {
+            let sigma = pair[0];
+            // an odd-length vector is malformed; treat the missing part as zero
+            let omega = pair.get(1).copied().unwrap_or(F_ZERO);
+
+            // |r|^2 decides both the reciprocal and whether the root is zero
+            let s2 = self.ctx.ins().fmul(sigma, sigma);
+            let w2 = self.ctx.ins().fmul(omega, omega);
+            let mag2 = self.ctx.ins().fadd(s2, w2);
+            let is_zero = self.ctx.ins().feq(mag2, F_ZERO);
+            // divide by 1 instead of 0 in the branch the select discards
+            let denom = self.ctx.make_select(is_zero, |_ctx, b| if b { one } else { mag2 });
+
+            // 1/r = conj(r)/|r|^2, so the s coefficient of (1 - s/r) is
+            // (-sigma + j*omega)/|r|^2; a zero root makes the factor a bare s.
+            let inv_re = self.ctx.ins().fdiv(sigma, denom);
+            let c1_re_nonzero = self.ctx.ins().fneg(inv_re);
+            let c1_im_nonzero = self.ctx.ins().fdiv(omega, denom);
+
+            let c0 = self.ctx.make_select(is_zero, |_ctx, b| if b { F_ZERO } else { one });
+            let c1_re =
+                self.ctx.make_select(is_zero, |_ctx, b| if b { one } else { c1_re_nonzero });
+            let c1_im =
+                self.ctx.make_select(is_zero, |_ctx, b| if b { F_ZERO } else { c1_im_nonzero });
+
+            // multiply the running polynomial by [c0, c1]
+            let mut next_re = vec![F_ZERO; re.len() + 1];
+            let mut next_im = vec![F_ZERO; re.len() + 1];
+            for i in 0..re.len() {
+                // times c0, whose imaginary part is always zero
+                let t_re = self.ctx.ins().fmul(re[i], c0);
+                let t_im = self.ctx.ins().fmul(im[i], c0);
+                next_re[i] = self.ctx.ins().fadd(next_re[i], t_re);
+                next_im[i] = self.ctx.ins().fadd(next_im[i], t_im);
+
+                // times c1, shifted up one power of s
+                let rr = self.ctx.ins().fmul(re[i], c1_re);
+                let ii = self.ctx.ins().fmul(im[i], c1_im);
+                let ri = self.ctx.ins().fmul(re[i], c1_im);
+                let ir = self.ctx.ins().fmul(im[i], c1_re);
+                let real = self.ctx.ins().fsub(rr, ii);
+                let imag = self.ctx.ins().fadd(ri, ir);
+                next_re[i + 1] = self.ctx.ins().fadd(next_re[i + 1], real);
+                next_im[i + 1] = self.ctx.ins().fadd(next_im[i + 1], imag);
+            }
+            re = next_re;
+            im = next_im;
+        }
+
+        // The conjugate pairs the LRM requires cancel the imaginary parts.
+        re
+    }
+
+    fn lower_laplace_state_space(
+        &mut self,
+        input: Value,
+        num: Vec<Value>,
+        den: Vec<Value>,
+    ) -> Value {
         let n = den.len().saturating_sub(1); // filter order
         if n == 0 {
             if num.is_empty() || den.is_empty() {

--- a/openvaf/openvaf/tests/integration.rs
+++ b/openvaf/openvaf/tests/integration.rs
@@ -505,6 +505,65 @@ fn test_adc() -> Result<()> {
     Ok(())
 }
 
+/// VAMS-2023 4.5.11.1-4.5.11.3: the root forms of the Laplace filter. Each one is
+/// paired in the model with a `laplace_nd` call whose coefficients spell out the
+/// same transfer function, so expanding the roots must reproduce them exactly --
+/// including a zero *at* zero, whose factor is a bare `s` rather than `1 - s/r`,
+/// and a conjugate pole pair, whose imaginary parts have to cancel. See
+/// `laplace_roots.va`.
+fn test_laplace_roots() -> Result<()> {
+    if stdx::IS_CI && cfg!(windows) {
+        return Ok(());
+    }
+
+    let desc = test_descriptor(&openvaf_test_data("osdi").join("laplace_roots.va"))?;
+    let model = desc.new_model();
+    model.process_params()?;
+    let mut instance = model.new_instance();
+    let mut sim = instance.mock_simulation(&model, desc.num_terminals, 300.0)?;
+
+    sim.set_voltage("in", 1.0);
+    for out in ["o1", "o2", "o3", "o4", "o5", "o6", "o7", "o8"] {
+        sim.set_voltage(out, 0.0);
+    }
+    // (root form, coefficient form) equation pairs, in source order: one state each
+    // for the two first-order filters, then two each for the second-order pair.
+    const PAIRS: [(usize, usize); 6] = [(0, 1), (2, 3), (4, 6), (5, 7), (8, 10), (9, 11)];
+
+    // The two equations of a pair have to hold the same state to be comparable, but
+    // the values differ *between* pairs so that a mix-up between the two states of
+    // the second-order filter cannot pass by coincidence.
+    for (i, (root_eq, coeff_eq)) in PAIRS.iter().enumerate() {
+        let x = 0.25 + 0.125 * i as f64;
+        sim.set_voltage(&format!("implicit_equation_{root_eq}"), x);
+        sim.set_voltage(&format!("implicit_equation_{coeff_eq}"), x);
+    }
+
+    instance.eval(&model, &mut sim, EvalFlags::empty());
+    instance.load_dae(&model, &mut sim);
+
+    for (root_eq, coeff_eq) in PAIRS {
+        let (root_resist, root_react) = sim.read_residual(&format!("implicit_equation_{root_eq}"));
+        let (coeff_resist, coeff_react) =
+            sim.read_residual(&format!("implicit_equation_{coeff_eq}"));
+        // The two sides compute the same coefficients by different routes -- one
+        // expands roots, the other reads them out -- so they agree to rounding
+        // rather than bit for bit. The residuals reach 1e12, which makes a relative
+        // comparison the only meaningful one.
+        float_cmp::assert_approx_eq!(f64, root_resist, coeff_resist, ulps = 8);
+        float_cmp::assert_approx_eq!(f64, root_react, coeff_react, ulps = 8);
+    }
+
+    // The outputs themselves must agree too, not just the internal equations.
+    for (root_out, coeff_out) in [("o1", "o2"), ("o3", "o4"), ("o5", "o6"), ("o7", "o8")] {
+        let root = sim.read_residual(&format!("flow({root_out})")).0;
+        let coeff = sim.read_residual(&format!("flow({coeff_out})")).0;
+        float_cmp::assert_approx_eq!(f64, root, coeff, ulps = 8);
+    }
+
+    Ok(())
+}
+
 harness! {
     // TODO: run this in CI, somehow this test is flakey tough regarding the linker invocation (and really slow)
     Test::from_dir("integration", &integration_test, &ignore_dev_tests, &project_root().join("integration_tests")),
@@ -514,5 +573,5 @@ harness! {
     Test::from_dir_filtered("vacask_spice", &vacask_spice_test, &is_va_file, &ignore_dev_tests, &vacask_devices().join("spice")),
     // VACASK simplified SPICE models
     Test::from_dir_filtered("vacask_spice_sn", &vacask_spice_sn_test, &is_va_file, &ignore_dev_tests, &vacask_devices().join("spice/sn")),
-    [Test::new("$limit", &test_limit),Test::new("noise", &test_noise),Test::new("arrays", &test_arrays),Test::new("cross_latch", &test_cross_latch),Test::new("laplace_nd_int", &test_laplace_nd_int),Test::new("vector_ports", &test_vector_ports),Test::new("qam16", &test_qam16),Test::new("cross_array", &test_cross_array),Test::new("adc", &test_adc),Test::new("indirect_opamp", &test_indirect_opamp)]
+    [Test::new("$limit", &test_limit),Test::new("noise", &test_noise),Test::new("arrays", &test_arrays),Test::new("cross_latch", &test_cross_latch),Test::new("laplace_nd_int", &test_laplace_nd_int),Test::new("vector_ports", &test_vector_ports),Test::new("qam16", &test_qam16),Test::new("cross_array", &test_cross_array),Test::new("adc", &test_adc),Test::new("indirect_opamp", &test_indirect_opamp),Test::new("laplace_roots", &test_laplace_roots)]
 }

--- a/openvaf/test_data/osdi/laplace_roots.snap
+++ b/openvaf/test_data/osdi/laplace_roots.snap
@@ -1,0 +1,99 @@
+param "$mfactor"
+units = "", desc = "Multiplier (Verilog-A $mfactor)", flags = ParameterFlags(PARA_KIND_INST)
+param "tau"
+units = "", desc = "", flags = ParameterFlags(0x0)
+param "tz"
+units = "", desc = "", flags = ParameterFlags(0x0)
+param "a"
+units = "", desc = "", flags = ParameterFlags(0x0)
+param "b"
+units = "", desc = "", flags = ParameterFlags(0x0)
+
+9 terminals
+node "in" units = "V", runits = "A"
+node "o1" units = "V", runits = "A"
+node "o2" units = "V", runits = "A"
+node "o3" units = "V", runits = "A"
+node "o4" units = "V", runits = "A"
+node "o5" units = "V", runits = "A"
+node "o6" units = "V", runits = "A"
+node "o7" units = "V", runits = "A"
+node "o8" units = "V", runits = "A"
+node(flow) "flow(o1)" units = "A", runits = "V"
+node(flow) "flow(o2)" units = "A", runits = "V"
+node(flow) "flow(o3)" units = "A", runits = "V"
+node(flow) "flow(o4)" units = "A", runits = "V"
+node(flow) "flow(o5)" units = "A", runits = "V"
+node(flow) "flow(o6)" units = "A", runits = "V"
+node(flow) "flow(o7)" units = "A", runits = "V"
+node(flow) "flow(o8)" units = "A", runits = "V"
+node "implicit_equation_0" units = "", runits = ""
+node "implicit_equation_1" units = "", runits = ""
+node "implicit_equation_2" units = "", runits = ""
+node "implicit_equation_3" units = "", runits = ""
+node "implicit_equation_4" units = "", runits = ""
+node "implicit_equation_5" units = "", runits = ""
+node "implicit_equation_6" units = "", runits = ""
+node "implicit_equation_7" units = "", runits = ""
+node "implicit_equation_8" units = "", runits = ""
+node "implicit_equation_9" units = "", runits = ""
+node "implicit_equation_10" units = "", runits = ""
+node "implicit_equation_11" units = "", runits = ""
+jacobian (o1, flow(o1)) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (o2, flow(o2)) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (o3, flow(o3)) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (o4, flow(o4)) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (o5, flow(o5)) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (o6, flow(o6)) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (o7, flow(o7)) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (o8, flow(o8)) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o1), o1) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o1), implicit_equation_0) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o2), o2) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o2), implicit_equation_1) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o3), in) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o3), o3) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o3), implicit_equation_2) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o4), in) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o4), o4) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o4), implicit_equation_3) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o5), o5) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o5), implicit_equation_4) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o5), implicit_equation_5) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o6), o6) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o6), implicit_equation_6) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o6), implicit_equation_7) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o7), o7) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o7), implicit_equation_8) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o8), o8) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (flow(o8), implicit_equation_10) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_0, in) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_0, implicit_equation_0) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_1, in) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_1, implicit_equation_1) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_2, in) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_2, implicit_equation_2) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_3, in) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_3, implicit_equation_3) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_4, implicit_equation_4) JacobianFlags(JACOBIAN_ENTRY_REACT | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_4, implicit_equation_5) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_5, in) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_5, implicit_equation_4) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_5, implicit_equation_5) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_6, implicit_equation_6) JacobianFlags(JACOBIAN_ENTRY_REACT | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_6, implicit_equation_7) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_7, in) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_7, implicit_equation_6) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_7, implicit_equation_7) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_8, implicit_equation_8) JacobianFlags(JACOBIAN_ENTRY_REACT | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_8, implicit_equation_9) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_9, in) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_9, implicit_equation_8) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_9, implicit_equation_9) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_10, implicit_equation_10) JacobianFlags(JACOBIAN_ENTRY_REACT | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_10, implicit_equation_11) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_RESIST_CONST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_11, in) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_11, implicit_equation_10) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT_CONST)
+jacobian (implicit_equation_11, implicit_equation_11) JacobianFlags(JACOBIAN_ENTRY_RESIST | JACOBIAN_ENTRY_REACT | JACOBIAN_ENTRY_REACT_CONST)
+0 states
+has bound_step false

--- a/openvaf/test_data/osdi/laplace_roots.va
+++ b/openvaf/test_data/osdi/laplace_roots.va
@@ -1,0 +1,42 @@
+`include "disciplines.vams"
+
+// VAMS-2023 4.5.11.1-4.5.11.3: `laplace_zp`, `laplace_zd` and `laplace_np` take
+// their zeros and/or poles as (real, imaginary) pairs. A.6.4 spells the vectors as
+// `constant_assignment_pattern_or_null`, which is the `'{...}` form used here.
+//
+// Each root form below is paired with a `laplace_nd` call whose coefficients are
+// the same transfer function written out, so expanding the roots must reproduce
+// them exactly.
+module laplace_roots(in, o1, o2, o3, o4, o5, o6, o7, o8);
+    input in;
+    output o1, o2, o3, o4, o5, o6, o7, o8;
+    electrical in, o1, o2, o3, o4, o5, o6, o7, o8;
+
+    parameter real tau = 1e-6;      // real pole at -1/tau
+    parameter real tz = 4e-7;       // real zero at -1/tz
+    parameter real a = 1e6;         // conjugate pole pair -a +- j*b
+    parameter real b = 2e6;
+
+    analog begin
+        // a real pole as a root vs the same denominator as coefficients
+        V(o1) <+ laplace_np(V(in), '{1.0}, '{-1.0 / tau, 0.0});
+        V(o2) <+ laplace_nd(V(in), '{1.0}, '{1.0, tau});
+
+        // a zero *at* zero, whose factor is a bare s rather than 1 - s/r
+        V(o3) <+ laplace_zp(V(in), '{0.0, 0.0}, '{-1.0 / tau, 0.0});
+        V(o4) <+ laplace_nd(V(in), '{0.0, 1.0}, '{1.0, tau});
+
+        // a real zero over a conjugate pole pair:
+        //   1 + 2a/(a^2+b^2) s + 1/(a^2+b^2) s^2
+        V(o5) <+ laplace_zd(V(in), '{-1.0 / tz, 0.0},
+                            '{1.0, 2.0 * a / (a * a + b * b), 1.0 / (a * a + b * b)});
+        V(o6) <+ laplace_nd(V(in), '{1.0, tz},
+                            '{1.0, 2.0 * a / (a * a + b * b), 1.0 / (a * a + b * b)});
+
+        // the conjugate pair itself given as roots: the expansion carries imaginary
+        // parts that have to cancel, leaving the same real coefficients as o6's
+        V(o7) <+ laplace_np(V(in), '{1.0}, '{-a, b, -a, -b});
+        V(o8) <+ laplace_nd(V(in), '{1.0},
+                            '{1.0, 2.0 * a / (a * a + b * b), 1.0 / (a * a + b * b)});
+    end
+endmodule

--- a/openvaf/test_data/ui/laplace_roots.va
+++ b/openvaf/test_data/ui/laplace_roots.va
@@ -1,0 +1,29 @@
+`include "disciplines.vams"
+
+// VAMS-2023 4.5.11.1-4.5.11.3: the zero-pole, zero-denominator and
+// numerator-pole forms of the Laplace filter. Each was rejected as "not
+// supported" before; all three are analog operators, so the usual restrictions
+// (no filter inside a conditional) still apply.
+module laplace_roots_ui(in, out);
+    input in;
+    output out;
+    electrical in, out;
+
+    parameter real tau = 1e-6;
+    parameter real tz = 4e-7;
+    parameter real a = 1e6;
+    parameter real b = 2e6;
+
+    analog begin
+        // zeros and poles, both as (real, imaginary) pairs
+        V(out) <+ laplace_zp(V(in), '{-1.0 / tz, 0.0}, '{-1.0 / tau, 0.0});
+        // zeros as roots, denominator as coefficients
+        V(out) <+ laplace_zd(V(in), '{-1.0 / tz, 0.0}, '{1.0, tau});
+        // numerator as coefficients, poles as roots -- here a conjugate pair
+        V(out) <+ laplace_np(V(in), '{1.0}, '{-a, b, -a, -b});
+        // a root at zero contributes a bare `s` factor
+        V(out) <+ laplace_zp(V(in), '{0.0, 0.0}, '{-1.0 / tau, 0.0});
+        // the optional tolerance argument is still accepted
+        V(out) <+ laplace_np(V(in), '{1.0}, '{-1.0 / tau, 0.0}, 1e-9);
+    end
+endmodule

--- a/sourcegen/src/hir_builtins.rs
+++ b/sourcegen/src/hir_builtins.rs
@@ -25,7 +25,7 @@ const ANALOG_OPERATORS: [&str; 17] = [
     "transition",
 ];
 
-const UNSUPPORTED: [&str; 48] = [
+const UNSUPPORTED: [&str; 45] = [
     "simprobe",
     "analog_node_alias",
     "analog_port_alias",
@@ -35,9 +35,6 @@ const UNSUPPORTED: [&str; 48] = [
     "zi_np",
     "zi_zd",
     "zi_zp",
-    "laplace_np",
-    "laplace_zd",
-    "laplace_zp",
     "last_crossing",
     "slew",
     "fclose",


### PR DESCRIPTION
Part of #19 (VAMS-2023 alignment) — Mantis 4848, the last remaining code item from that issue's table apart from `last_crossing`.

## The gap

Of the four Laplace filters, only `laplace_nd` worked. `laplace_zp`, `laplace_zd` and `laplace_np` were in `UNSUPPORTED`, so any filter written with roots rather than coefficients was rejected:

```
error: function 'laplace_zp' is currently not supported by OpenVAF
```

## What this changes

The three root forms are lowered by expanding their root vectors into polynomial coefficients and reusing the existing `laplace_nd` state-space realization. `lower_laplace_nd` is split so the realization takes coefficient values directly, and the root forms feed it expanded ones — no second realization, no new DAE machinery.

The expansion computes `prod_k (1 - s/r_k)` for a root vector given as (real, imaginary) pairs:

- **The number of roots is fixed at compile time** (array lengths are static), so only the coefficient arithmetic is emitted; the roots themselves stay runtime values.
- **A root at zero** contributes a bare `s` factor rather than `1 - s/r`, as §4.5.11.1 requires. Since the roots are runtime values, that cannot be a compile-time case split, so it is a select on each factor coefficient — and the reciprocal divides by 1 rather than 0 in the branch the select discards.
- **Complex roots** are carried through with their imaginary parts and dropped at the end. The LRM requires a complex root's conjugate to be present, and it is exactly that which makes the product real, so no case analysis on whether a given root is real is needed.

## Tests

`test_data/osdi/laplace_roots.va` pairs every root form with a `laplace_nd` call whose coefficients spell out the same transfer function, and `integration.rs::test_laplace_roots` drives the pair through the mock simulator and asserts the two realizations agree equation for equation, plus at the outputs. It covers:

- a real pole as a root (`laplace_np`) against the same denominator as coefficients,
- a zero **at** zero (`laplace_zp`), whose factor is a bare `s`,
- a real zero over a second-order denominator (`laplace_zd`),
- and a **conjugate pole pair given as roots** (`laplace_np`), where the imaginary parts have to cancel to reproduce the real coefficients.

The two sides compute the same coefficients by different routes, so they agree to rounding rather than bit for bit; residuals reach 1e12, which makes the comparison a relative (ULP) one.

`test_data/ui/laplace_roots.va` covers all three forms plus the optional tolerance argument, and compiles with no diagnostics where each was an error before.

## Not in scope

The `zi_*` Z-transform filters (§4.5.12) stay unsupported. They are discrete-time: they sample their input every `T` and hold it across a transition `tau`, so they need the sampling and cross-timestep machinery tracked in #37, not a polynomial expansion.

Note the vectors must be parameters or `'{...}` constant patterns, per A.6.4 (`analog_filter_function_arg`). `laplace_nd` is more lenient today and also accepts array variables; this PR does not change that either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HXTzrarRpdGMgaWt89qpoM
